### PR TITLE
feat: 浅色模式语法标记配色优化 + 编辑模式标题/Wikilink 特效同步

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -89,7 +89,6 @@ settings:
                 value: theme-dark-radiation
 */
 
-
 /* @settings
 name: 🗂️ Phycat card Layout
 name.zh: 🗂️ Phycat 卡片布局设置
@@ -128,6 +127,80 @@ settings:
                 
 */
 
+/* @settings
+name: ✏️ Phycat syntax mark setting
+name.zh: ✏️ Phycat 语法标记设置
+id: phycat-syntax
+settings:
+    -
+        id: bold-light-color
+        title: Bold text color (Light Mode)
+        title.zh: 粗体文字颜色（亮色模式）
+        description: Override bold text color for all light themes.
+        description.zh: 覆盖所有亮色主题的粗体颜色。
+        type: variable-color
+        format: hex
+        default: '#e91e63'
+    -
+        id: italic-light-color
+        title: Italic text color (Light Mode)
+        title.zh: 斜体文字颜色（亮色模式）
+        description: Override italic text color for all light themes.
+        description.zh: 覆盖所有亮色主题的斜体颜色。
+        type: variable-color
+        format: hex
+        default: '#0277bd'
+    -
+        id: bold-dark-color
+        title: Bold text color (Dark Mode)
+        title.zh: 粗体文字颜色（暗色模式）
+        description: Override bold text color for all dark themes.
+        description.zh: 覆盖所有暗色主题的粗体颜色。
+        type: variable-color
+        format: hex
+        default: '#ff5555'
+    -
+        id: italic-dark-color
+        title: Italic text color (Dark Mode)
+        title.zh: 斜体文字颜色（暗色模式）
+        description: Override italic text color for all dark themes.
+        description.zh: 覆盖所有暗色主题的斜体颜色。
+        type: variable-color
+        format: hex
+        default: '#bd93f9'
+    -
+        id: highlight-light-color
+        title: Highlight color (Light Mode)
+        title.zh: 高亮颜色（亮色模式）
+        description: Override the highlight/mark gradient color for light themes. Defaults to each theme's primary color.
+        description.zh: 覆盖亮色主题的高亮渐变颜色。默认跟随各主题主色。
+        type: variable-color
+        format: hex
+        default: '#ff7096'
+    -
+        id: highlight-dark-color
+        title: Highlight color (Dark Mode)
+        title.zh: 高亮颜色（暗色模式）
+        description: Override the highlight/mark gradient color for dark themes. Defaults to each theme's primary color.
+        description.zh: 覆盖暗色主题的高亮渐变颜色。默认跟随各主题主色。
+        type: variable-color
+        format: hex
+        default: '#ff5555'
+*/
+
+/* @settings
+name: 🔗 Phycat link setting
+name.zh: 🔗 Phycat 链接设置
+id: phycat-links
+settings:
+    -
+        id: editor-wikilink-style
+        title: Wikilink bracket & hover effects in Editor
+        title.zh: 编辑模式 Wikilink 括号装饰与 hover 特效
+        description: Show single bracket decoration and hover animation for [[wikilinks]] in editing/live-preview mode, matching reading mode style.
+        description.zh: 在编辑/实时预览模式中为 [[内部链接]] 显示单括号装饰和悬停动画效果，与阅读模式一致。
+        type: class-toggle
+*/
 
 /* =================================================================
    文件列表样式 (File Explorer) - 彩虹玻璃容器版 (动态图标版)
@@ -191,7 +264,14 @@ name: 📑 Phycat heading setting
 name.ZH: 📑 Phycat 标题设置
 id: phycat-headings
 settings:
-    - 
+    -
+        id: editor-heading-hover
+        title: Enable heading hover effects in Editor
+        title.zh: 编辑模式标题 hover 特效
+        description: Enable the same heading hover animations in editing/live-preview mode as in reading mode.
+        description.zh: 在编辑/实时预览模式中启用与阅读模式相同的标题悬停动画效果。
+        type: class-toggle
+    -
         id: headings-color-setting
         title: Headings Colors
         title.zh: 标题文字颜色设置
@@ -480,5 +560,4927 @@ settings:
         default: 1.5
 */
 
+:root {
+  --h3-icon-shape: url("data:image/svg+xml;utf8,<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><path d='M4.571 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286z'/></svg>");
+  --h4-icon-shape: url("data:image/svg+xml;utf8,<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><path d='M4.571 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 22.857c1.257 0 2.286-1.029 2.286-2.286s-1.029-2.286-2.286-2.286-2.286 1.029-2.286 2.286 1.029 2.286 2.286 2.286z'/></svg>");
+  --h5-icon-shape: url("data:image/svg+xml;utf8,<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><path d='M4.571 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 22.857c1.257 0 2.286-1.029 2.286-2.286s-1.029-2.286-2.286-2.286-2.286 1.029-2.286 2.286 1.029 2.286 2.286 2.286zM4.571 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 11.429c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286z'/></svg>");
+  --h6-icon-shape: url("data:image/svg+xml;utf8,<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><path d='M4.571 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 11.429c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 16c1.257 0 2.286-1.029 2.286-2.286s-1.029-2.286-2.286-2.286-2.286 1.029-2.286 2.286 1.029 2.286 2.286 2.286z'/></svg>");
+  --list-spacing: 0.075em;
+}
+body {
+  --blockquote-line-height: 1.6;
+  --table-line-height: 1.8;
+  --letter-spacing: 1px;
+  --code-size: 0.95rem;
+  --code-white-space: pre;
+  --code-radius: 8px;
+  --checkbox-size: 1.25rem;
+  --checkmark-color: #ffffff;
+  --table-border-radius: 8px;
+  --text-faint: color-mix(in srgb, var(--primary-color), transparent 20%);
+  --link-external-decoration-hover: none;
+  --titlebar-background: transparent;
+  --titlebar-background-focused: transparent;
+  --he-title-bar-inactive-pinned-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    #fff 20%
+  );
+  --h1-line-height: 1.2;
+  --h2-line-height: 1.5;
+  --h3-line-height: 1.5;
+  --h4-line-height: 1.4;
+  --h5-line-height: 1.4;
+  --h6-line-height: 1.4;
+  --file-line-width: 900px;
+  --h1-spacing-scale-start: 1.5;
+  --h1-spacing-scale-end: 1.5;
+  --h2-spacing-scale-start: 1.5;
+  --h2-spacing-scale-end: 1.5;
+  --h3-spacing-scale-start: 1.5;
+  --h3-spacing-scale-end: 1.5;
+  --h4-spacing-scale-start: 1.5;
+  --h4-spacing-scale-end: 1.5;
+  --h5-spacing-scale-start: 1.5;
+  --h5-spacing-scale-end: 1.5;
+  --h6-spacing-scale-start: 1.5;
+  --h6-spacing-scale-end: 1.5;
+  --heading-spacing: 0.5rem;
+  --h3-spacing-scale: 1.6;
+  --h2-spacing-scale: 0.2;
+  --word-spacing: 2px;
+  --h1-letter-spacing: -0.015em;
+  --h2-letter-spacing: -0.011em;
+  --h3-letter-spacing: -0.008em;
+  --h4-letter-spacing: -0.005em;
+  --h5-letter-spacing: -0.002em;
+  --h6-letter-spacing: 0em;
+  --h1-line-height: 1.2;
+  --h2-line-height: 1.2;
+  --h3-line-height: 1.3;
+  --h4-line-height: 1.4;
+  --h5-line-height: 1.4;
+  --h6-line-height: 1.4;
+  --h1-size: 1.618em;
+  --h2-size: 1.462em;
+  --h3-size: 1.318em;
+  --h4-size: 1.2em;
+  --h5-size: 1.2em;
+  --h6-size: 1.2em;
+  .token.keyword,
+  .token.tag,
+  .token.selector {
+    color: var(--code-keyword);
+    font-weight: bold;
+  }
+  .token.function,
+  .token.class-name {
+    color: var(--code-function);
+  }
+  .token.string,
+  .token.attr-value {
+    color: var(--code-string);
+  }
+  .token.comment {
+    color: var(--code-comment);
+    font-style: italic;
+  }
+  .token.number,
+  .token.boolean {
+    color: var(--code-value);
+  }
+  .token.operator,
+  .token.variable {
+    color: var(--code-operator);
+  }
+  .token.property,
+  .token.attr-name {
+    color: var(--code-property);
+  }
+  .token.punctuation {
+    color: var(--code-punctuation);
+  }
+  .token.important,
+  .token.bold {
+    font-weight: bold;
+    color: var(--code-important, var(--code-keyword));
+  }
+  .token.italic {
+    font-style: italic;
+  }
+  .token.url {
+    color: var(--code-string);
+    text-decoration: underline;
+  }
+}
+body.theme-dark.theme-dark-vampire,
+body.theme-dark:not(.theme-dark-abyss):not(.theme-dark-radiation) {
+  --bg-color: #282a36;
+  --text-color: #f8f8f2;
+  --text-color-secondary: #d0d0d0;
+  --border-color: #44475a;
+  --primary-color: #ff5555;
+  --secondary-color: #bd93f9;
+  --accent-color: #8be9fd;
+  --glow-color: rgba(255, 85, 85, 0.6);
+  --hover-background-color: rgb(255, 85, 85);
+  --select-text-bg-color: rgba(255, 16, 16, 0.466);
+  --link-hover-color: #ff92d0;
+  --h1-underline-color: var(--primary-color);
+  --h2-bg-image: radial-gradient(
+    ellipse at center bottom,
+    rgba(255, 85, 85, 0.15),
+    transparent 70%
+  );
+  --h2-bg-image-hover: radial-gradient(
+    ellipse at center bottom,
+    rgba(255, 85, 85, 0.25),
+    transparent 60%
+  );
+  --code-block-bg: #282a36;
+  --code-keyword: #ff79c6;
+  --code-function: #50fa7b;
+  --code-string: #f1fa8c;
+  --code-comment: #6272a4;
+  --code-property: #66d9ef;
+  --code-value: #bd93f9;
+  --code-punctuation: #f8f8f2;
+  --code-tag: #ff79c6;
+  --code-operator: #ff79c6;
+  --code-important: #ff79c6;
+}
+body.theme-dark.theme-dark-abyss {
+  --bg-color: #0f111a;
+  --text-color: #d6deeb;
+  --text-color-secondary: #7e8c9f;
+  --border-color: #1f2233;
+  --primary-color: #00b7c0;
+  --secondary-color: #2e8bd6;
+  --accent-color: #d500f9;
+  --glow-color: rgba(0, 243, 255, 0.5);
+  --hover-background-color: #00f3ff;
+  --select-text-bg-color: rgba(7, 243, 255, 0.445);
+  --link-hover-color: #82aaff;
+  --h1-underline-color: var(--primary-color);
+  --h2-bg-image: radial-gradient(
+    ellipse at center bottom,
+    rgba(0, 243, 255, 0.15),
+    transparent 70%
+  );
+  --h2-bg-image-hover: radial-gradient(
+    ellipse at center bottom,
+    rgba(0, 243, 255, 0.25),
+    transparent 60%
+  );
+  --code-block-bg: #0f111a;
+  --code-keyword: #c792ea;
+  --code-function: #82aaff;
+  --code-string: #ecc48d;
+  --code-comment: #637777;
+  --code-property: #80cbc4;
+  --code-value: #f78c6c;
+  --code-punctuation: #d6deeb;
+  --code-tag: #ff5370;
+  --code-operator: #89ddff;
+  --code-important: #c792ea;
+}
+body.theme-dark.theme-dark-radiation {
+  --bg-color: #1b1d1b;
+  --text-color: #e6e6e6;
+  --text-color-secondary: #99a699;
+  --border-color: #333933;
+  --primary-color: #4cd964;
+  --secondary-color: #ffc107;
+  --accent-color: #29b6f6;
+  --glow-color: rgba(76, 217, 100, 0.4);
+  --hover-background-color: #4cd964;
+  --select-text-bg-color: rgba(76, 217, 100, 0.3);
+  --link-hover-color: #a5d6a7;
+  --h1-underline-color: var(--primary-color);
+  --h2-bg-image: radial-gradient(
+    ellipse at center bottom,
+    rgba(76, 217, 100, 0.1),
+    transparent 70%
+  );
+  --h2-bg-image-hover: radial-gradient(
+    ellipse at center bottom,
+    rgba(76, 217, 100, 0.2),
+    transparent 60%
+  );
+  --code-block-bg: #1b1d1b;
+  --code-keyword: #ffcb6b;
+  --code-function: #4cd964;
+  --code-string: #c3e88d;
+  --code-comment: #546e7a;
+  --code-property: #4cd964;
+  --code-value: #f78c6c;
+  --code-punctuation: #e6e6e6;
+  --code-tag: #ff5370;
+  --code-operator: #89ddff;
+  --code-important: #ffcb6b;
+}
+body.theme-light.theme-light-sakura,
+body.theme-light:not(.theme-light-sky):not(.theme-light-forest):not(
+    .theme-light-mint
+  ):not(.theme-light-mauve):not(.theme-light-golden):not(
+    .theme-light-cheery
+  ):not(.theme-light-prussian) {
+  --primary-color: #ff7096;
+  --secondary-color: #bd93f9;
+  --bg-color: #fff7fa;
+  --light-deep: #e91e63;
+  --light-light: #ffb7cd;
+  --light-lighter: #ffe3ec;
+  --light-pale: #fff0f5;
+  --text-color: #1c1719;
+  --text-color-secondary: #3f3a3b;
+  --link-hover-color: #d81b60;
+  --select-text-bg-color: rgba(255, 112, 150, 0.3);
+  --glow-color: rgba(255, 112, 150, 0.5);
+  --border-color: color-mix(in srgb, var(--primary-color), transparent 60%);
+  --h2-bg-gradient: linear-gradient(
+    to right,
+    var(--light-light),
+    var(--primary-color),
+    var(--light-light)
+  );
+  --h2-shadow-color: rgba(61, 184, 211, 0.15);
+  --h2-shadow-hover: rgba(61, 184, 211, 0.35);
+  --text-bold: var(--bold-light-color, #e91e63);
+  --text-italic: var(--italic-light-color, #0277bd);
+  --text-highlight: var(--highlight-light-color, #0277bd);
+  --code-normal: #546e7a;
+  --code-string: #2e7d32;
+  --code-comment: #b0bec5;
+  --code-keyword: #d81b60;
+  --code-function: #8e24aa;
+  --code-value: #f57c00;
+  --code-tag: #d81b60;
+  --code-operator: #8e24aa;
+  --code-property: #00897b;
+  --code-punctuation: #78909c;
+  --code-block-bg: #fff4f8;
+  --code-block-header-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 92%
+  );
+}
+body.theme-light.theme-light-sky {
+  --primary-color: #3498db;
+  --secondary-color: #5296d5;
+  --bg-color: #f4faff;
+  --light-deep: #1a5276;
+  --light-light: #85c1e9;
+  --light-lighter: #aed6f1;
+  --light-pale: #ebf5fb;
+  --text-color: #080d12;
+  --text-color-secondary: #0a1112;
+  --link-hover-color: #2980b9;
+  --select-text-bg-color: rgba(52, 152, 219, 0.25);
+  --glow-color: rgba(52, 152, 219, 0.5);
+  --code-block-bg: var(--light-pale);
+  --border-color: color-mix(in srgb, var(--primary-color), transparent 60%);
+  --h2-bg-gradient: linear-gradient(
+    to right,
+    var(--light-light),
+    var(--primary-color),
+    var(--light-light)
+  );
+  --h2-shadow-color: rgba(52, 152, 219, 0.15);
+  --h2-shadow-hover: rgba(52, 152, 219, 0.35);
+  --text-bold: var(--bold-light-color, #1a5276);
+  --text-italic: var(--italic-light-color, #c56200);
+  --text-highlight: var(--highlight-light-color, #c56200);
+  --code-normal: #24292e;
+  --code-keyword: #d73a49;
+  --code-function: #6f42c1;
+  --code-string: #032f62;
+  --code-value: #005cc5;
+  --code-comment: #6a737d;
+  --code-tag: #22863a;
+  --code-operator: #d73a49;
+  --code-property: #005cc5;
+  --code-punctuation: #24292e;
+  --code-block-header-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 94%
+  );
+}
+body.theme-light.theme-light-forest {
+  --primary-color: #11aa63;
+  --secondary-color: #14ae9c;
+  --bg-color: #f2f9f5;
+  --light-deep: #008145;
+  --light-light: #43bd84;
+  --light-lighter: #68eaad;
+  --light-pale: #f9fffb;
+  --text-color: #000000;
+  --text-color-secondary: #5c7066;
+  --link-hover-color: #009a52;
+  --select-text-bg-color: rgba(17, 170, 99, 0.25);
+  --glow-color: rgba(17, 170, 99, 0.5);
+  --code-block-bg: var(--light-pale);
+  --border-color: color-mix(in srgb, var(--primary-color), transparent 60%);
+  --h2-bg-gradient: linear-gradient(
+    to right,
+    var(--light-light),
+    var(--light-lighter),
+    var(--light-light)
+  );
+  --h2-shadow-color: rgba(17, 170, 99, 0.15);
+  --h2-shadow-hover: rgba(17, 170, 99, 0.35);
+  --text-bold: var(--bold-light-color, #8e24aa);
+  --text-italic: var(--italic-light-color, #bf6c00);
+  --text-highlight: var(--highlight-light-color, #bf6c00);
+  --code-normal: #383a42;
+  --code-keyword: #a626a4;
+  --code-function: #4078f2;
+  --code-string: #50a14f;
+  --code-value: #986801;
+  --code-comment: #9ca0a4;
+  --code-tag: #e45649;
+  --code-operator: #0184bc;
+  --code-property: #4078f2;
+  --code-punctuation: #383a42;
+  --code-block-header-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 94%
+  );
+}
+body.theme-light.theme-light-forest h2 {
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+body.theme-light.theme-light-mint {
+  --primary-color: #3db8bf;
+  --secondary-color: #2acd9e;
+  --bg-color: #f4fdff;
+  --light-deep: #089ba3;
+  --light-light: #7aeaf0;
+  --light-lighter: #b2ebf2;
+  --light-pale: #e0f7fa;
+  --text-color: #263238;
+  --text-color-secondary: #546e7a;
+  --link-hover-color: #00838f;
+  --select-text-bg-color: #7aeaf077;
+  --glow-color: rgba(61, 184, 191, 0.4);
+  --border-color: color-mix(in srgb, var(--primary-color), transparent 75%);
+  --h2-bg-gradient: linear-gradient(to right, #80f7c4, #3db8d3, #80f7c4);
+  --h2-shadow-color: rgba(61, 184, 191, 0.15);
+  --h2-shadow-hover: rgba(61, 184, 191, 0.35);
+  --text-bold: var(--bold-light-color, #c2185b);
+  --text-italic: var(--italic-light-color, #e65100);
+  --text-highlight: var(--highlight-light-color, #e65100);
+  --code-normal: #37474f;
+  --code-string: #00695c;
+  --code-comment: #90a4ae;
+  --code-keyword: #0097a7;
+  --code-function: #0277bd;
+  --code-value: #f57f17;
+  --code-tag: #0097a7;
+  --code-operator: #0277bd;
+  --code-property: #00695c;
+  --code-punctuation: #546e7a;
+  --code-block-bg: #f0fcff;
+  --code-block-header-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 94%
+  );
+}
+body.theme-light.theme-light-mauve {
+  --primary-color: #a06eb4;
+  --secondary-color: #6a3f7a;
+  --bg-color: #fafafc;
+  --light-deep: #6a3f7a;
+  --light-light: #d4b6e0;
+  --light-lighter: #f3e5f5;
+  --light-pale: #f3e5f5;
+  --text-color: #4a235a;
+  --text-color-secondary: #6a3f7a;
+  --link-hover-color: #ba68c8;
+  --select-text-bg-color: #f0d7f966;
+  --glow-color: rgba(160, 110, 180, 0.4);
+  --border-color: color-mix(in srgb, var(--primary-color), transparent 75%);
+  --h2-bg-gradient: linear-gradient(to right, #d8b4e2, #a06eb4, #d8b4e2);
+  --h2-shadow-color: rgba(160, 110, 180, 0.15);
+  --h2-shadow-hover: rgba(160, 110, 180, 0.35);
+  --text-bold: var(--bold-light-color, #00838f);
+  --text-italic: var(--italic-light-color, #c56200);
+  --text-highlight: var(--highlight-light-color, #c56200);
+  --code-background: #f2eff9;
+  --code-normal: #5e35b1;
+  --code-normal: #4a148c;
+  --code-string: #2e7d32;
+  --code-comment: #9fa8da;
+  --code-keyword: #ba68c8;
+  --code-function: #7b1fa2;
+  --code-value: #f57c00;
+  --code-tag: #ba68c8;
+  --code-operator: #7b1fa2;
+  --code-punctuation: #6a1b9a;
+  --code-block-bg: #fcfbfd;
+  --code-block-header-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 94%
+  );
+}
+body.theme-light.theme-light-golden {
+  --primary-color: #f59e0b;
+  --secondary-color: #b45309;
+  --bg-color: #fffbeb;
+  --light-deep: #b45309;
+  --light-light: #fbbf24;
+  --light-lighter: #fef3c7;
+  --light-pale: #fffbeb;
+  --text-color: #78350f;
+  --text-color-secondary: #92400e;
+  --link-hover-color: #f59e0b;
+  --select-text-bg-color: #f59e0b33;
+  --glow-color: rgba(245, 158, 11, 0.4);
+  --border-color: color-mix(in srgb, var(--primary-color), transparent 75%);
+  --h2-bg-gradient: linear-gradient(to right, #fcd34d, #f59e0b, #fcd34d);
+  --h2-shadow-color: rgba(245, 158, 11, 0.15);
+  --h2-shadow-hover: rgba(245, 158, 11, 0.35);
+  --text-bold: var(--bold-light-color, #4527a0);
+  --text-italic: var(--italic-light-color, #00796b);
+  --text-highlight: var(--highlight-light-color, #00796b);
+  --code-background: #fff7ed;
+  --code-normal: #92400e;
+  --code-normal: #5d4037;
+  --code-string: #689f38;
+  --code-comment: #a1887f;
+  --code-keyword: #d84315;
+  --code-function: #f57f17;
+  --code-value: #e65100;
+  --code-tag: #d84315;
+  --code-operator: #f57f17;
+  --code-punctuation: #8d6e63;
+  --code-block-bg: #fffbf0;
+  --code-block-header-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 94%
+  );
+}
+body.theme-light.theme-light-cheery {
+  --primary-color: #aa1141;
+  --secondary-color: #810000;
+  --bg-color: #fffbfb;
+  --light-deep: #9a0036;
+  --light-light: #ffa6a6;
+  --light-lighter: #fec2c2;
+  --light-pale: #fffbfb;
+  --text-color: #333333;
+  --text-color-secondary: #870e0e;
+  --link-hover-color: #d81b60;
+  --select-text-bg-color: rgba(123, 123, 123, 0.507);
+  --glow-color: rgba(170, 17, 65, 0.4);
+  --border-color: color-mix(in srgb, var(--primary-color), transparent 75%);
+  --h2-bg-gradient: linear-gradient(to right, #b41919, #ea68b6, #b41919);
+  --h2-shadow-color: rgba(170, 17, 65, 0.15);
+  --h2-shadow-hover: rgba(170, 17, 65, 0.35);
+  --text-bold: var(--bold-light-color, #00695c);
+  --text-italic: var(--italic-light-color, #4527a0);
+  --text-highlight: var(--highlight-light-color, #4527a0);
+  --code-background: rgb(177 108 108 / 2%);
+  --code-normal: #9a0000;
+  --code-normal: #4a0d18;
+  --code-string: #2e7d32;
+  --code-comment: #8d6e63;
+  --code-keyword: #c2185b;
+  --code-function: #d32f2f;
+  --code-value: #e65100;
+  --code-tag: #c2185b;
+  --code-operator: #d32f2f;
+  --code-punctuation: #870e0e;
+  --code-block-bg: #fff5f7;
+  --code-block-header-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 94%
+  );
+}
+body.theme-light.theme-light-prussian {
+  --primary-color: #1d4e89;
+  --secondary-color: #003153;
+  --bg-color: #f0f6fa;
+  --light-deep: #003153;
+  --light-light: #6ba3cc;
+  --light-lighter: #e1edf5;
+  --light-pale: #f0f6fa;
+  --text-color: #003153;
+  --text-color-secondary: #1d4e89;
+  --link-hover-color: #2962ff;
+  --select-text-bg-color: rgba(29, 78, 137, 0.2);
+  --glow-color: rgba(29, 78, 137, 0.4);
+  --border-color: color-mix(in srgb, var(--primary-color), transparent 75%);
+  --h2-bg-gradient: linear-gradient(to right, #6ba3cc, #1d4e89, #6ba3cc);
+  --h2-shadow-color: rgba(29, 78, 137, 0.15);
+  --h2-shadow-hover: rgba(29, 78, 137, 0.35);
+  --text-bold: var(--bold-light-color, #c62828);
+  --text-italic: var(--italic-light-color, #bf6c00);
+  --text-highlight: var(--highlight-light-color, #bf6c00);
+  --code-background: #ebf5fa;
+  --code-normal: #0f3057;
+  --code-normal: #37474f;
+  --code-string: #2e7d32;
+  --code-comment: #90a4ae;
+  --code-keyword: #0277bd;
+  --code-function: #006064;
+  --code-value: #e65100;
+  --code-tag: #0277bd;
+  --code-operator: #006064;
+  --code-punctuation: #455a64;
+  --code-block-bg: #f5f9fc;
+  --code-block-header-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 94%
+  );
+}
+body.theme-light {
+  --glow-shadow-text: 0 0 5px var(--glow-color);
+  --glow-shadow-box: 0 0 5px var(--glow-color);
+  --background-primary: color-mix(in srgb, var(--bg-color), #fff 2%);
+  --background-card: color-mix(
+    in srgb,
+    var(--primary-color),
+    #fff calc(var(--bg-mix-percent) * 1%)
+  );
+  --background-primary-alt: color-mix(in srgb, var(--bg-color), #000 3%);
+  --background-secondary: color-mix(in srgb, var(--bg-color), #fff 5%);
+  --background-secondary-alt: color-mix(in srgb, var(--bg-color), #000 8%);
+  --text-normal: var(--text-color);
+  --text-muted: var(--text-color-secondary);
+  --mermaid-text-color: var(--text-color);
+  --text-accent: var(--primary-color);
+  --text-accent-hover: var(--link-hover-color);
+  --list-marker-color: var(--primary-color);
+  --interactive-accent: var(--primary-color);
+  --interactive-accent-hover: var(--link-hover-color);
+  --text-selection: #dce3e9b6;
+  --background-modifier-hover: rgba(0, 0, 0, 0.05);
+  --background-modifier-active-hover: rgba(0, 0, 0, 0.1);
+  --background-modifier-border: var(--border-color);
+  --background-modifier-border-hover: var(--secondary-color);
+  --background-modifier-error: #d32f2f;
+  --background-modifier-success: #388e3c;
+  --code-background: var(--code-block-bg);
+  --code-normal: var(--text-color);
+  --input-shadow: inset 0 0 0 1px var(--border-color);
+  --input-shadow-hover: inset 0 0 0 1px var(--secondary-color);
+  --checkbox-bg-unchecked: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 90%
+  );
+  --checkbox-border-unchecked: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 50%
+  );
+  --checkbox-bg-checked: var(--primary-color);
+  --checkbox-shadow-checked: 0 2px 5px
+    color-mix(in srgb, var(--primary-color), transparent 60%);
+  --table-bg: rgba(255, 255, 255, 0.4);
+  --table-border-inner: rgba(0, 0, 0, 0.06);
+  --table-row-hover-bg: rgba(0, 0, 0, 0.03);
+  --table-th-bg: color-mix(in srgb, var(--primary-color), white 90%);
+  --table-th-border: color-mix(in srgb, var(--primary-color), transparent 80%);
+  --table-cell-hover-bg: color-mix(in srgb, var(--primary-color), white 80%);
+  --table-cell-hover-text: var(--primary-color);
+  --border-color: color-mix(in srgb, var(--primary-color), transparent 50%);
+  --blockquote-background-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    white 96%
+  );
+  --setting-items-background: color-mix(
+    in srgb,
+    var(--light-lighter),
+    transparent 94%
+  );
+  --indentation-guide-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    white 50%
+  );
+  --tag-background: color-mix(in srgb, var(--primary-color), white 85%);
+  --tag-background-hover: color-mix(in srgb, var(--primary-color), white 75%);
+  --tag-border-color: color-mix(in srgb, var(--primary-color), white 50%);
+  --tag-border-color-hover: var(--primary-color);
+  --h1-color: var(--h1-light-color, #000000);
+  --h2-color: var(--h2-light-color, #000000);
+  --h3-color: var(--h3-light-color, #000000);
+  --h4-color: var(--h4-light-color, #000000);
+  --h5-color: var(--h5-light-color, #000000);
+  --h6-color: var(--h6-light-color, #000000);
+}
+body.theme-dark {
+  --text-highlight: var(--highlight-dark-color, var(--primary-color));
+  --glow-shadow-text: 0 0 8px var(--glow-color);
+  --glow-shadow-box: 0 0 8px var(--glow-color);
+  --background-primary: var(--bg-color);
+  --background-primary-alt: var(--bg-color);
+  --background-secondary: color-mix(in srgb, var(--bg-color), #000 15%);
+  --background-secondary-alt: color-mix(in srgb, var(--bg-color), #000 25%);
+  --text-normal: var(--text-color);
+  --text-muted: var(--text-color-secondary);
+  --mermaid-text-color: #000;
+  --text-accent: var(--primary-color);
+  --text-accent-hover: var(--link-hover-color);
+  --list-marker-color: var(--primary-color);
+  --interactive-accent: var(--primary-color);
+  --interactive-accent-hover: var(--link-hover-color);
+  --text-selection: var(--select-text-bg-color);
+  --background-modifier-hover: rgba(255, 255, 255, 0.05);
+  --background-modifier-active-hover: rgba(255, 255, 255, 0.1);
+  --background-modifier-border: var(--border-color);
+  --background-modifier-border-hover: var(--secondary-color);
+  --background-modifier-error: #ff5555;
+  --background-modifier-success: #50fa7b;
+  --code-background: var(--code-block-bg);
+  --code-normal: var(--text-color);
+  --checkbox-bg-unchecked: rgba(255, 255, 255, 0.05);
+  --checkbox-border-unchecked: rgba(255, 255, 255, 0.3);
+  --checkbox-bg-checked: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 80%
+  );
+  --checkbox-shadow-checked: 0 0 8px var(--primary-color);
+  --table-bg: rgba(255, 255, 255, 0.02);
+  --table-border-inner: rgba(255, 255, 255, 0.05);
+  --table-row-hover-bg: rgba(255, 255, 255, 0.03);
+  --table-th-bg: color-mix(in srgb, var(--primary-color), transparent 95%);
+  --table-th-border: color-mix(in srgb, var(--primary-color), transparent 85%);
+  --table-cell-hover-bg: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 85%
+  );
+  --table-cell-hover-text: #fff;
+  --setting-items-background: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 96%
+  );
+  --tag-background: color-mix(in srgb, var(--primary-color), transparent 85%);
+  --tag-background-hover: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 75%
+  );
+  --tag-border-color: color-mix(in srgb, var(--primary-color), transparent 50%);
+  --tag-border-color-hover: var(--primary-color);
+  --h1-color: var(--h1-dark-color, #ffffff);
+  --h2-color: var(--h2-dark-color, #ffffff);
+  --h3-color: var(--h3-dark-color, #ffffff);
+  --h4-color: var(--h4-dark-color, #ffffff);
+  --h5-color: var(--h5-dark-color, #ffffff);
+  --h6-color: var(--h6-dark-color, #ffffff);
+}
+body {
+  --line-height-normal: 2.2;
+  --line-height-tight: 1.3;
+  --line-height-customize: var(--line-height-normal);
+}
+.markdown-preview-view,
+.markdown-source-view {
+  letter-spacing: var(--letter-spacing);
+  position: relative;
+}
+.markdown-preview-view p,
+.markdown-preview-view li {
+  color: var(--text-color-secondary);
+  word-spacing: var(--word-spacing);
+}
+.markdown-preview-view,
+.markdown-source-view.mod-cm6 .cm-scroller {
+  line-height: var(--line-height-customize);
+}
+body .markdown-preview-view h1,
+body .markdown-source-view.mod-cm6 .HyperMD-header-1 {
+  color: var(--h1-color) !important;
+}
+body .markdown-preview-view h2,
+body .markdown-source-view.mod-cm6 .HyperMD-header-2 {
+  color: var(--h2-color) !important;
+}
+body .markdown-preview-view h3,
+body .markdown-source-view.mod-cm6 .HyperMD-header-3 {
+  color: var(--h3-color) !important;
+}
+body .markdown-preview-view h4,
+body .markdown-source-view.mod-cm6 .HyperMD-header-4 {
+  color: var(--h4-color) !important;
+}
+body .markdown-preview-view h5,
+body .markdown-source-view.mod-cm6 .HyperMD-header-5 {
+  color: var(--h5-color) !important;
+}
+body .markdown-preview-view h6,
+body .markdown-source-view.mod-cm6 .HyperMD-header-6 {
+  color: var(--h6-color) !important;
+}
+.markdown-preview-view h1,
+.markdown-preview-view h2,
+.markdown-preview-view h3,
+.markdown-preview-view h4,
+.markdown-preview-view h5,
+.markdown-preview-view h6,
+.markdown-source-view.mod-cm6 .HyperMD-header {
+  color: var(--text-color);
+  font-weight: bold;
+  position: relative;
+  transition: all 0.3s ease;
+  margin-block-start: var(--heading-spacing);
+  margin-block-end: var(--heading-spacing);
+}
+.markdown-preview-view h1 {
+  margin-block-start: calc(
+    var(--heading-spacing) * var(--h1-spacing-scale-start)
+  );
+  margin-block-end: calc(var(--heading-spacing) * var(--h1-spacing-scale-end));
+}
+.markdown-preview-view h2 {
+  margin-block-start: calc(
+    var(--heading-spacing) * var(--h2-spacing-scale-start)
+  );
+  margin-block-end: calc(var(--heading-spacing) * var(--h2-spacing-scale-end));
+}
+.markdown-preview-view h3 {
+  margin-block-start: calc(
+    var(--heading-spacing) * var(--h3-spacing-scale-start)
+  );
+  margin-block-end: calc(var(--heading-spacing) * var(--h3-spacing-scale-end));
+}
+.markdown-preview-view h4 {
+  margin-block-start: calc(
+    var(--heading-spacing) * var(--h4-spacing-scale-start)
+  );
+  margin-block-end: calc(var(--heading-spacing) * var(--h4-spacing-scale-end));
+}
+.markdown-preview-view h5 {
+  margin-block-start: calc(
+    var(--heading-spacing) * var(--h5-spacing-scale-start)
+  );
+  margin-block-end: calc(var(--heading-spacing) * var(--h5-spacing-scale-end));
+}
+.markdown-preview-view h6 {
+  margin-block-start: calc(
+    var(--heading-spacing) * var(--h6-spacing-scale-start)
+  );
+  margin-block-end: calc(var(--heading-spacing) * var(--h6-spacing-scale-end));
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-1 {
+  padding-top: calc(
+    var(--heading-spacing) * var(--h1-spacing-scale-start) - 0.25rem
+  );
+  padding-bottom: calc(
+    var(--heading-spacing) * var(--h1-spacing-scale-end) - 0.25rem
+  );
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-2 {
+  padding-top: calc(
+    var(--heading-spacing) * var(--h2-spacing-scale-start) - 0.25rem
+  );
+  padding-bottom: calc(
+    var(--heading-spacing) * var(--h2-spacing-scale-end) - 0.25rem
+  );
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-3 {
+  padding-top: calc(
+    var(--heading-spacing) * var(--h3-spacing-scale-start) - 0.25rem
+  );
+  padding-bottom: calc(
+    var(--heading-spacing) * var(--h3-spacing-scale-end) - 0.25rem
+  );
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-4 {
+  padding-top: calc(
+    var(--heading-spacing) * var(--h4-spacing-scale-start) - 0.25rem
+  );
+  padding-bottom: calc(
+    var(--heading-spacing) * var(--h4-spacing-scale-end) - 0.25rem
+  );
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-5 {
+  padding-top: calc(
+    var(--heading-spacing) * var(--h5-spacing-scale-start) - 0.25rem
+  );
+  padding-bottom: calc(
+    var(--heading-spacing) * var(--h5-spacing-scale-end) - 0.25rem
+  );
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-6 {
+  padding-top: calc(
+    var(--heading-spacing) * var(--h6-spacing-scale-start) - 0.25rem
+  );
+  padding-bottom: calc(
+    var(--heading-spacing) * var(--h6-spacing-scale-end) - 0.25rem
+  );
+}
+.theme-light .markdown-preview-view .heading-collapse-indicator {
+  margin-inline-start: -47px !important;
+}
+.theme-dark .markdown-preview-view .heading-collapse-indicator {
+  margin-inline-start: -26px !important;
+}
+.theme-light .markdown-preview-view h2 .heading-collapse-indicator {
+  margin-inline-start: -19px !important;
+}
+.theme-dark.h2-style-dark-capsule
+  .markdown-preview-view
+  h2
+  .heading-collapse-indicator {
+  margin-inline-start: -19px !important;
+}
+.theme-dark:not(.h2-style-dark-capsule)
+  .markdown-preview-view
+  h2
+  .heading-collapse-indicator {
+  margin-inline-start: -48px !important;
+}
+.theme-dark .markdown-preview-view h3 .heading-collapse-indicator,
+.theme-light .markdown-preview-view h3 .heading-collapse-indicator {
+  margin-inline-start: -43px !important;
+}
+.theme-dark.h1-align-left .markdown-preview-view h1 .heading-collapse-indicator,
+.theme-light.h1-align-left
+  .markdown-preview-view
+  h1
+  .heading-collapse-indicator {
+  margin-inline-start: -50px !important;
+}
+.markdown-source-view.mod-cm6 .cm-fold-indicator .collapse-indicator {
+  inset-inline-end: 22px;
+}
+.h1-align-left
+  .markdown-source-view.mod-cm6
+  .cm-fold-indicator
+  .collapse-indicator {
+  inset-inline-end: 32px;
+}
+.theme-light.h2-style-capsule
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2
+  .collapse-indicator,
+.theme-dark.h2-style-dark-capsule
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2
+  .collapse-indicator {
+  inset-inline-end: -2px;
+}
+.theme-light.h2-style-capsule
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2
+  .collapse-indicator
+  svg,
+.theme-dark.h2-style-dark-capsule
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2
+  .collapse-indicator
+  svg,
+.theme-light.h2-style-capsule
+  .markdown-preview-view
+  h2
+  .heading-collapse-indicator
+  svg,
+.theme-dark.h2-style-dark-capsule
+  .markdown-preview-view
+  h2
+  .heading-collapse-indicator
+  svg {
+  color: #eee;
+}
+.theme-light .markdown-preview-view h1,
+.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-1 {
+  font-weight: 700;
+  line-height: 1.4;
+  padding-bottom: 12px;
+  display: table;
+  width: auto;
+  min-width: 120px;
+  text-align: center;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  position: relative;
+  transition:
+    color 0.3s ease,
+    transform 0.3s ease;
+}
+.theme-light .markdown-preview-view h1::after,
+.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-1::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 40px;
+  height: 4px;
+  border-radius: 4px;
+  background: var(--h2-bg-gradient);
+  background-size: 100% auto;
+  transform: translateX(-50%);
+  transition:
+    width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    transform 0.3s ease;
+}
+.theme-light .markdown-preview-view h1:hover {
+  color: var(--primary-color);
+  transform: translateY(-2px);
+}
+.theme-light .markdown-preview-view h1:hover::after {
+  width: 100%;
+}
+.theme-light.h1-align-left .markdown-preview-view h1,
+.theme-light.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1 {
+  text-align: left;
+  margin-left: 0 !important;
+  margin-right: auto !important;
+  padding-left: 32px;
+}
+.theme-light.h1-align-left .markdown-preview-view h1::before,
+.theme-light.h1-align-left
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-1::before {
+  content: "";
+  position: absolute;
+  width: 10px;
+  height: 22px;
+  border-radius: 6px;
+  top: 45%;
+  transform: translateY(-50%);
+  margin-top: -6px;
+  left: 2px;
+  background-color: var(--secondary-color);
+  opacity: 0.5;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 0;
+}
+.theme-light.h1-align-left .markdown-preview-view h1::after,
+.theme-light.h1-align-left
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-1::after {
+  bottom: auto;
+  width: 10px;
+  height: 22px;
+  border-radius: 6px;
+  top: 45%;
+  transform: translateY(-50%);
+  margin-top: 4px;
+  left: 8px;
+  background: var(--primary-color);
+  mix-blend-mode: multiply;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.05s;
+  z-index: 1;
+}
+.theme-light.h1-align-left .markdown-preview-view h1:hover {
+  color: var(--primary-color);
+  transform: translateX(5px);
+}
+.theme-light.h1-align-left .markdown-preview-view h1:hover::before {
+  height: 32px;
+  margin-top: 0;
+  left: 4px;
+  width: 6px;
+  opacity: 0.3;
+  border-radius: 3px;
+}
+.theme-light.h1-align-left .markdown-preview-view h1:hover::after {
+  height: 26px;
+  margin-top: 0;
+  left: 12px;
+  width: 6px;
+  border-radius: 3px;
+  box-shadow: 0 0 10px color-mix(in srgb, var(--primary-color), transparent 60%);
+}
+.theme-light.h2-style-capsule .markdown-preview-view h2,
+.theme-light.h2-style-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2 {
+  color: #fff !important;
+  font-weight: bold;
+  text-decoration: none !important;
+  display: inline-block;
+  width: fit-content;
+  padding: 6px 16px;
+  border-radius: 8px;
+  background-image: var(--h2-bg-gradient) !important;
+  background-size: 200% auto;
+  background-position: 0% center;
+  background-repeat: no-repeat;
+  box-shadow: 0 2px 5px var(--h2-shadow-color);
+  border: 1px solid transparent !important;
+  background-clip: padding-box;
+  overflow: hidden;
+  border-bottom: none !important;
+  transition:
+    background-position 0.5s ease-out,
+    transform 0.4s ease,
+    box-shadow 0.4s ease;
+}
+.theme-light.h2-style-capsule .markdown-preview-view h2:hover {
+  background-position: 100% center;
+  transform: scale(1.01);
+  box-shadow: 0 8px 20px var(--h2-shadow-hover);
+}
+.theme-light.h2-style-capsule
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2
+  .cm-formatting-header {
+  color: rgba(255, 255, 255, 0.6) !important;
+}
+.theme-light:not(.h2-style-capsule) .markdown-preview-view h2,
+.theme-light.h2-style-twin .markdown-preview-view h2,
+.theme-light:not(.h2-style-capsule)
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2,
+.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2 {
+  background: none !important;
+  box-shadow: none !important;
+  border: none !important;
+  border-radius: 0 !important;
+  position: relative;
+  padding-left: 20px;
+  padding-right: 0;
+  display: block;
+  width: 100%;
+  transition: all 0.3s ease;
+}
+.theme-light:not(.h2-style-capsule)
+  .markdown-preview-view
+  h2
+  .heading-collapse-indicator,
+.theme-light.h2-style-twin
+  .markdown-preview-view
+  h2
+  .heading-collapse-indicator {
+  margin-inline-start: -43px !important;
+}
+.theme-light:not(.h2-style-capsule) .markdown-preview-view h2::before,
+.theme-light.h2-style-twin .markdown-preview-view h2::before,
+.theme-light:not(.h2-style-capsule)
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::before,
+.theme-light.h2-style-twin
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: auto;
+  margin-top: 0.1em;
+  height: 1em;
+  width: 5px;
+  background-color: var(--primary-color);
+  border-radius: 4px;
+  opacity: 1;
+  transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+.theme-light:not(.h2-style-capsule)
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::before,
+.theme-light.h2-style-twin
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::before {
+  margin-top: 0.2em;
+}
+.theme-light:not(.h2-style-capsule) .markdown-preview-view h2::after,
+.theme-light.h2-style-twin .markdown-preview-view h2::after,
+.theme-light:not(.h2-style-capsule)
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::after,
+.theme-light.h2-style-twin
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::after {
+  content: "";
+  position: absolute;
+  left: 8px;
+  top: auto;
+  margin-top: 0.3em;
+  height: 0.6em;
+  width: 2px;
+  background-color: var(--secondary-color);
+  border-radius: 2px;
+  opacity: 0.6;
+  transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1) 0.05s;
+}
+.theme-light:not(.h2-style-capsule)
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::after,
+.theme-light.h2-style-twin
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::after {
+  margin-top: 0.4em;
+}
+.theme-light:not(.h2-style-capsule) .markdown-preview-view h2:hover,
+.theme-light.h2-style-twin .markdown-preview-view h2:hover {
+  color: var(--primary-color) !important;
+  transform: translateX(5px);
+}
+.theme-light:not(.h2-style-capsule) .markdown-preview-view h2:hover::before,
+.theme-light.h2-style-twin .markdown-preview-view h2:hover::before {
+  top: auto;
+  margin-top: 0em;
+  height: 1.4em;
+  opacity: 0.4;
+}
+.theme-light:not(.h2-style-capsule) .markdown-preview-view h2:hover::after,
+.theme-light.h2-style-twin .markdown-preview-view h2:hover::after {
+  top: auto;
+  margin-top: 0.15em;
+  height: 1.1em;
+  width: 4px;
+  opacity: 1;
+  background-color: var(--primary-color);
+}
+.theme-light:not(.h2-style-capsule)
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2
+  .cm-formatting-header,
+.theme-light.h2-style-twin
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2
+  .cm-formatting-header {
+  color: var(--text-faint) !important;
+  opacity: 0.4;
+}
+.theme-light .markdown-preview-view h3 {
+  width: fit-content;
+  padding-left: 15px;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+.theme-light .markdown-preview-view h3::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 5px;
+  height: 1.3rem;
+  border-radius: 4px;
+  background-color: var(--primary-color);
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+.theme-light .markdown-preview-view h3:hover {
+  padding-left: 20px;
+  color: var(--primary-color);
+}
+.theme-light .markdown-preview-view h3:hover::before {
+  height: 24px;
+  width: 7px;
+  box-shadow: 0 0 0 3px var(--light-lighter);
+}
+.theme-light .markdown-preview-view h4 {
+  padding-left: 20px;
+}
+.theme-light .markdown-preview-view h4::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  transition: all 0.3s ease;
+}
+.theme-light .markdown-preview-view h4:hover {
+  color: var(--light-deep) !important;
+  transform: translateX(6px);
+}
+.theme-light .markdown-preview-view h4:hover::before {
+  transform: translateY(-50%) scale(1.3);
+  box-shadow: 0 0 0 4px var(--light-lighter);
+}
+.theme-light .markdown-preview-view h5 {
+  padding-left: 20px;
+}
+.theme-light .markdown-preview-view h5::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 2px solid var(--primary-color);
+  box-sizing: border-box;
+  transition: all 0.3s ease;
+}
+.theme-light .markdown-preview-view h5:hover {
+  color: var(--light-deep) !important;
+  transform: translateX(6px);
+}
+.theme-light .markdown-preview-view h5:hover::before {
+  background-color: var(--primary-color);
+  transform: translateY(-50%) scale(1.2);
+  box-shadow: 0 0 0 3px var(--light-lighter);
+}
+.theme-light .markdown-preview-view h6 {
+  padding-left: 20px;
+}
+.theme-light .markdown-preview-view h6::before {
+  content: "-";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--primary-color);
+  font-weight: bold;
+  line-height: 1;
+  transition: all 0.3s ease;
+}
+.theme-light .markdown-preview-view h6:hover {
+  color: var(--light-deep) !important;
+  transform: translateX(6px);
+}
+.theme-light .markdown-preview-view h6:hover::before {
+  transform: translateY(-50%) scaleX(1.8);
+}
+.theme-dark .markdown-preview-view h1,
+.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-1 {
+  padding-bottom: 12px;
+  border-bottom: none;
+  display: table;
+  width: auto;
+  min-width: 120px;
+  text-align: center;
+  margin-top: 2em;
+  margin-bottom: 1em;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  position: relative;
+}
+.h1-align-left .markdown-preview-view h1 {
+  padding-bottom: 0;
+}
+.theme-dark .markdown-preview-view h1::after,
+.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-1::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 40px;
+  height: 4px;
+  border-radius: 4px;
+  background: var(--h1-underline-color);
+  box-shadow: 0 0 5px rgba(255, 85, 85, 0.4);
+  transform: translateX(-50%);
+  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+}
+.theme-dark .markdown-preview-view h1:hover {
+  text-shadow: var(--glow-shadow-text);
+}
+.theme-dark .markdown-preview-view h1:hover::after {
+  width: 100%;
+  box-shadow: 0 0 15px var(--h1-underline-color);
+}
+.theme-dark.h1-align-left .markdown-preview-view h1,
+.theme-dark.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1 {
+  text-align: left;
+  margin-left: 0 !important;
+  margin-right: auto !important;
+  padding-left: 32px;
+}
+.theme-dark.h1-align-left .markdown-preview-view h1::before,
+.theme-dark.h1-align-left
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-1::before {
+  content: "";
+  position: absolute;
+  top: 45%;
+  transform: translateY(-50%);
+  margin-top: -6px;
+  left: 2px;
+  width: 10px;
+  height: 22px;
+  border-radius: 6px;
+  background-color: var(--secondary-color);
+  opacity: 0.6;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 0;
+}
+.theme-dark.h1-align-left .markdown-preview-view h1::after,
+.theme-dark.h1-align-left
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-1::after {
+  bottom: auto;
+  top: 45%;
+  transform: translateY(-50%);
+  margin-top: 4px;
+  left: 8px;
+  width: 10px;
+  height: 22px;
+  border-radius: 6px;
+  background: var(--primary-color);
+  mix-blend-mode: screen;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.05s;
+  z-index: 1;
+}
+.theme-dark.h1-align-left .markdown-preview-view h1:hover {
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+.theme-dark.h1-align-left .markdown-preview-view h1:hover::before {
+  height: 32px;
+  margin-top: 0;
+  left: 4px;
+  width: 6px;
+  opacity: 0.4;
+}
+.theme-dark.h1-align-left .markdown-preview-view h1:hover::after {
+  height: 26px;
+  margin-top: 0;
+  left: 12px;
+  width: 6px;
+  box-shadow: 0 0 15px var(--primary-color);
+}
+.theme-dark.h2-style-dark-capsule .markdown-preview-view h2,
+.theme-dark.h2-style-dark-capsule
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2 {
+  width: fit-content;
+  padding: 5px 16px;
+  border-radius: 8px;
+  display: inline-block;
+  background-color: rgba(255, 255, 255, 0.02);
+  background-image: var(--h2-bg-image);
+  background-repeat: no-repeat;
+  background-position: center bottom;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
+  border-bottom: 1px solid transparent;
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  transition:
+    color 0.5s ease,
+    transform 0.5s ease,
+    box-shadow 0.5s ease;
+}
+.theme-dark.h2-style-dark-capsule .markdown-preview-view h2::after,
+.theme-dark.h2-style-dark-capsule
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background-image: var(--h2-bg-image-hover);
+  background-repeat: no-repeat;
+  background-position: center bottom;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+.theme-dark.h2-style-dark-capsule .markdown-preview-view h2:hover {
+  color: var(--primary-color);
+  text-shadow: var(--glow-shadow-text);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transform: translateY(-1px);
+}
+.theme-dark.h2-style-dark-capsule .markdown-preview-view h2:hover::after {
+  opacity: 1;
+}
+.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2,
+.theme-dark.h2-style-dark-twin .markdown-preview-view h2,
+.theme-dark:not(.h2-style-dark-capsule)
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2,
+.theme-dark.h2-style-dark-twin .markdown-source-view.mod-cm6 .HyperMD-header-2 {
+  background: none !important;
+  box-shadow: none !important;
+  border: none !important;
+  border-radius: 0 !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  position: relative;
+  padding-left: 20px;
+  padding-right: 0;
+  display: block;
+  width: 100%;
+  transition: all 0.3s ease;
+}
+.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2::before,
+.theme-dark.h2-style-dark-twin .markdown-preview-view h2::before,
+.theme-dark:not(.h2-style-dark-capsule)
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::before,
+.theme-dark.h2-style-dark-twin
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: auto;
+  margin-top: 0.2em;
+  height: 1em;
+  width: 5px;
+  background-color: var(--primary-color);
+  border-radius: 4px;
+  opacity: 0.8;
+  box-shadow: 0 0 8px color-mix(in srgb, var(--primary-color), transparent 50%);
+  transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2::after,
+.theme-dark.h2-style-dark-twin .markdown-preview-view h2::after,
+.theme-dark:not(.h2-style-dark-capsule)
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::after,
+.theme-dark.h2-style-dark-twin
+  .markdown-source-view.mod-cm6
+  .HyperMD-header-2::after {
+  content: "";
+  position: absolute;
+  left: 8px;
+  top: auto;
+  margin-top: 0.4em;
+  height: 0.6em;
+  width: 2px;
+  background-color: var(--secondary-color);
+  border-radius: 2px;
+  opacity: 0.6;
+  transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1) 0.05s;
+}
+.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2:hover,
+.theme-dark.h2-style-dark-twin .markdown-preview-view h2:hover {
+  color: var(--primary-color) !important;
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2:hover::before,
+.theme-dark.h2-style-dark-twin .markdown-preview-view h2:hover::before {
+  top: auto;
+  margin-top: 0em;
+  height: 1.4em;
+  opacity: 0.5;
+}
+.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2:hover::after,
+.theme-dark.h2-style-dark-twin .markdown-preview-view h2:hover::after {
+  top: auto;
+  margin-top: 0.15em;
+  height: 1.1em;
+  width: 4px;
+  opacity: 1;
+  background-color: var(--primary-color);
+  box-shadow: 0 0 12px var(--primary-color);
+}
+.theme-dark .markdown-preview-view h3 {
+  padding-left: 15px;
+  display: block;
+  transition:
+    padding-left 0.3s ease,
+    color 0.3s ease;
+}
+.theme-dark .markdown-preview-view h3::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 1.3rem;
+  background: var(--primary-color);
+  border-radius: 2px;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  opacity: 0.8;
+}
+.theme-dark .markdown-preview-view h3:hover {
+  color: var(--primary-color);
+  padding-left: 20px;
+  text-shadow: var(--glow-shadow-text);
+}
+.theme-dark .markdown-preview-view h3:hover::before {
+  height: 24px;
+  opacity: 1;
+  box-shadow: var(--glow-shadow-box);
+}
+.theme-dark .markdown-preview-view h4 {
+  display: flex;
+  align-items: center;
+}
+.theme-dark .markdown-preview-view h4::before {
+  content: "";
+  margin-right: 10px;
+  display: inline-block;
+  background-color: var(--primary-color);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  flex-shrink: 0;
+}
+.theme-dark .markdown-preview-view h4:hover {
+  color: var(--primary-color);
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+.theme-dark .markdown-preview-view h4:hover::before {
+  transform: scale(1.2);
+  box-shadow: var(--glow-shadow-box);
+}
+.theme-dark .markdown-preview-view h5 {
+  display: flex;
+  align-items: center;
+}
+.theme-dark .markdown-preview-view h5::before {
+  content: "";
+  margin-right: 10px;
+  display: inline-block;
+  background-color: transparent;
+  border: 1.5px solid var(--primary-color);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  transition: all 0.3s ease;
+  flex-shrink: 0;
+}
+.theme-dark .markdown-preview-view h5:hover {
+  color: var(--primary-color);
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+.theme-dark .markdown-preview-view h5:hover::before {
+  background-color: transparent;
+  border-color: var(--primary-color);
+  box-shadow: var(--glow-shadow-box);
+  transform: scale(1.2);
+}
+.theme-dark .markdown-preview-view h6 {
+  display: flex;
+  align-items: center;
+}
+.theme-dark .markdown-preview-view h6::before {
+  content: "-";
+  color: var(--primary-color);
+  margin-right: 11px;
+  display: inline-block;
+  font-weight: bold;
+  transition: all 0.3s ease;
+}
+.theme-dark .markdown-preview-view h6:hover {
+  color: var(--primary-color);
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+.theme-dark .markdown-preview-view h6:hover::before {
+  text-shadow: var(--glow-shadow-text);
+  transform: scaleX(1.5);
+}
+.markdown-preview-view h3::after,
+.markdown-preview-view h4::after,
+.markdown-preview-view h5::after,
+.markdown-preview-view h6::after {
+  content: " ";
+  display: inline-block;
+  height: 1.2em;
+  width: 1.2em;
+  vertical-align: top;
+  margin-left: 8px;
+  background-color: var(--primary-color);
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+  opacity: 0.5;
+}
+.theme-light h3::after,
+.theme-light h4::after,
+.theme-light h5::after,
+.theme-light h6::after {
+  background-color: var(--light-light) !important;
+  opacity: 0.5;
+}
+.markdown-preview-view h3::after {
+  -webkit-mask-image: var(--h3-icon-shape);
+  mask-image: var(--h3-icon-shape);
+}
+.markdown-preview-view h4::after {
+  -webkit-mask-image: var(--h4-icon-shape);
+  mask-image: var(--h4-icon-shape);
+}
+.markdown-preview-view h5::after {
+  -webkit-mask-image: var(--h5-icon-shape);
+  mask-image: var(--h5-icon-shape);
+}
+.markdown-preview-view h6::after {
+  -webkit-mask-image: var(--h6-icon-shape);
+  mask-image: var(--h6-icon-shape);
+}
+.markdown-source-view.mod-cm6 .HyperMD-header {
+  font-weight: bold;
+  line-height: 1.4;
+  position: relative;
+}
+.markdown-source-view.mod-cm6 .cm-formatting-header {
+  color: var(--primary-color);
+  font-family: var(--font-monospace);
+  font-weight: normal;
+  margin-right: 8px;
+  opacity: 0.4;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-1 {
+  text-align: center;
+  justify-content: center;
+  border-bottom: none;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-1::after {
+  content: "";
+  display: block;
+  width: 40px;
+  height: 4px;
+  border-radius: 4px;
+  background: var(--primary-color);
+  background-image: var(
+    --h2-bg-gradient,
+    linear-gradient(to right, var(--primary-color), var(--primary-color))
+  );
+  margin: 8px auto 0 auto;
+  opacity: 0.8;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-3 {
+  padding-left: 20px;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-3::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: 0;
+  width: 5px;
+  height: 1.3rem;
+  border-radius: 4px;
+  background-color: var(--primary-color);
+  opacity: 0.8;
+  pointer-events: none;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-4 {
+  padding-left: 20px;
+  transition: all 0.3s ease;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-4::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  pointer-events: none;
+  transition: all 0.3s ease;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-5 {
+  padding-left: 20px;
+  transition: all 0.3s ease;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-5::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: transparent;
+  border: 2px solid var(--primary-color);
+  box-sizing: border-box;
+  background-color: var(--bg-color, transparent);
+  pointer-events: none;
+  transition: all 0.3s ease;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-6 {
+  padding-left: 20px;
+  transition: all 0.3s ease;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-6::before {
+  content: "-";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--primary-color);
+  font-weight: bold;
+  line-height: 1;
+  pointer-events: none;
+  transition: all 0.3s ease;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header:hover::before {
+  opacity: 1;
+  border-color: var(--primary-color);
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-3::after,
+.markdown-source-view.mod-cm6 .HyperMD-header-4::after,
+.markdown-source-view.mod-cm6 .HyperMD-header-5::after,
+.markdown-source-view.mod-cm6 .HyperMD-header-6::after {
+  content: "";
+  display: inline-block;
+  vertical-align: top;
+  width: 1.2em;
+  height: 1.2em;
+  margin-left: 8px;
+  background-color: var(--primary-color);
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+  opacity: 0.3;
+  pointer-events: none;
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-3::after {
+  -webkit-mask-image: var(--h3-icon-shape);
+  mask-image: var(--h3-icon-shape);
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-4::after {
+  -webkit-mask-image: var(--h4-icon-shape);
+  mask-image: var(--h4-icon-shape);
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-5::after {
+  -webkit-mask-image: var(--h5-icon-shape);
+  mask-image: var(--h5-icon-shape);
+}
+.markdown-source-view.mod-cm6 .HyperMD-header-6::after {
+  -webkit-mask-image: var(--h6-icon-shape);
+  mask-image: var(--h6-icon-shape);
+}
 
-:root{--h3-icon-shape:url("data:image/svg+xml;utf8,<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><path d='M4.571 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286z'/></svg>");--h4-icon-shape:url("data:image/svg+xml;utf8,<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><path d='M4.571 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 22.857c1.257 0 2.286-1.029 2.286-2.286s-1.029-2.286-2.286-2.286-2.286 1.029-2.286 2.286 1.029 2.286 2.286 2.286z'/></svg>");--h5-icon-shape:url("data:image/svg+xml;utf8,<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><path d='M4.571 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 22.857c1.257 0 2.286-1.029 2.286-2.286s-1.029-2.286-2.286-2.286-2.286 1.029-2.286 2.286 1.029 2.286 2.286 2.286zM4.571 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 11.429c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286z'/></svg>");--h6-icon-shape:url("data:image/svg+xml;utf8,<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><path d='M4.571 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM4.571 11.429c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 18.286c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 25.143c-1.257 0-2.286 1.029-2.286 2.286s1.029 2.286 2.286 2.286 2.286-1.029 2.286-2.286-1.029-2.286-2.286-2.286zM11.429 16c1.257 0 2.286-1.029 2.286-2.286s-1.029-2.286-2.286-2.286-2.286 1.029-2.286 2.286 1.029 2.286 2.286 2.286z'/></svg>");--list-spacing:0.075em}body{--blockquote-line-height:1.6;--table-line-height:1.8;--letter-spacing:1px;--code-size:0.95rem;--code-white-space:pre;--code-radius:8px;--checkbox-size:1.25rem;--checkmark-color:#ffffff;--table-border-radius:8px;--text-faint:color-mix(in srgb, var(--primary-color), transparent 20%);--link-external-decoration-hover:none;--titlebar-background:transparent;--titlebar-background-focused:transparent;--he-title-bar-inactive-pinned-bg:color-mix(in srgb, var(--primary-color), #fff 20%);--h1-line-height:1.2;--h2-line-height:1.5;--h3-line-height:1.5;--h4-line-height:1.4;--h5-line-height:1.4;--h6-line-height:1.4;--file-line-width:900px;--h1-spacing-scale-start:1.5;--h1-spacing-scale-end:1.5;--h2-spacing-scale-start:1.5;--h2-spacing-scale-end:1.5;--h3-spacing-scale-start:1.5;--h3-spacing-scale-end:1.5;--h4-spacing-scale-start:1.5;--h4-spacing-scale-end:1.5;--h5-spacing-scale-start:1.5;--h5-spacing-scale-end:1.5;--h6-spacing-scale-start:1.5;--h6-spacing-scale-end:1.5;--heading-spacing:0.5rem;--h3-spacing-scale:1.6;--h2-spacing-scale:0.2;--word-spacing:2px;--h1-letter-spacing:-0.015em;--h2-letter-spacing:-0.011em;--h3-letter-spacing:-0.008em;--h4-letter-spacing:-0.005em;--h5-letter-spacing:-0.002em;--h6-letter-spacing:0em;--h1-line-height:1.2;--h2-line-height:1.2;--h3-line-height:1.3;--h4-line-height:1.4;--h5-line-height:1.4;--h6-line-height:1.4;--h1-size:1.618em;--h2-size:1.462em;--h3-size:1.318em;--h4-size:1.2em;--h5-size:1.2em;--h6-size:1.2em;.token.keyword,    .token.tag,    .token.selector{color:var(--code-keyword);font-weight:bold}.token.function,    .token.class-name{color:var(--code-function)}.token.string,    .token.attr-value{color:var(--code-string)}.token.comment{color:var(--code-comment);font-style:italic}.token.number,    .token.boolean{color:var(--code-value)}.token.operator,    .token.variable{color:var(--code-operator)}.token.property,    .token.attr-name{color:var(--code-property)}.token.punctuation{color:var(--code-punctuation)}.token.important,    .token.bold{font-weight:bold;color:var(--code-important, var(--code-keyword))}.token.italic{font-style:italic}.token.url{color:var(--code-string);text-decoration:underline}}body.theme-dark.theme-dark-vampire,body.theme-dark:not(.theme-dark-abyss):not(.theme-dark-radiation){--bg-color:#282a36;--text-color:#f8f8f2;--text-color-secondary:#d0d0d0;--border-color:#44475a;--primary-color:#ff5555;--secondary-color:#bd93f9;--accent-color:#8be9fd;--glow-color:rgba(255, 85, 85, 0.6);--hover-background-color:rgb(255, 85, 85);--select-text-bg-color:rgba(255, 16, 16, 0.466);--link-hover-color:#ff92d0;--h1-underline-color:var(--primary-color);--h2-bg-image:radial-gradient(ellipse at center bottom, rgba(255, 85, 85, 0.15), transparent 70%);--h2-bg-image-hover:radial-gradient(ellipse at center bottom, rgba(255, 85, 85, 0.25), transparent 60%);--code-block-bg:#282a36;--code-keyword:#ff79c6;--code-function:#50fa7b;--code-string:#f1fa8c;--code-comment:#6272a4;--code-property:#66d9ef;--code-value:#bd93f9;--code-punctuation:#f8f8f2;--code-tag:#ff79c6;--code-operator:#ff79c6;--code-important:#ff79c6}body.theme-dark.theme-dark-abyss{--bg-color:#0f111a;--text-color:#d6deeb;--text-color-secondary:#7e8c9f;--border-color:#1f2233;--primary-color:#00b7c0;--secondary-color:#2e8bd6;--accent-color:#d500f9;--glow-color:rgba(0, 243, 255, 0.5);--hover-background-color:#00f3ff;--select-text-bg-color:rgba(7, 243, 255, 0.445);--link-hover-color:#82aaff;--h1-underline-color:var(--primary-color);--h2-bg-image:radial-gradient(ellipse at center bottom, rgba(0, 243, 255, 0.15), transparent 70%);--h2-bg-image-hover:radial-gradient(ellipse at center bottom, rgba(0, 243, 255, 0.25), transparent 60%);--code-block-bg:#0f111a;--code-keyword:#c792ea;--code-function:#82aaff;--code-string:#ecc48d;--code-comment:#637777;--code-property:#80cbc4;--code-value:#f78c6c;--code-punctuation:#d6deeb;--code-tag:#ff5370;--code-operator:#89ddff;--code-important:#c792ea}body.theme-dark.theme-dark-radiation{--bg-color:#1b1d1b;--text-color:#e6e6e6;--text-color-secondary:#99a699;--border-color:#333933;--primary-color:#4cd964;--secondary-color:#ffc107;--accent-color:#29b6f6;--glow-color:rgba(76, 217, 100, 0.4);--hover-background-color:#4cd964;--select-text-bg-color:rgba(76, 217, 100, 0.3);--link-hover-color:#a5d6a7;--h1-underline-color:var(--primary-color);--h2-bg-image:radial-gradient(ellipse at center bottom, rgba(76, 217, 100, 0.1), transparent 70%);--h2-bg-image-hover:radial-gradient(ellipse at center bottom, rgba(76, 217, 100, 0.2), transparent 60%);--code-block-bg:#1b1d1b;--code-keyword:#ffcb6b;--code-function:#4cd964;--code-string:#c3e88d;--code-comment:#546e7a;--code-property:#4cd964;--code-value:#f78c6c;--code-punctuation:#e6e6e6;--code-tag:#ff5370;--code-operator:#89ddff;--code-important:#ffcb6b}body.theme-light.theme-light-sakura,body.theme-light:not(.theme-light-sky):not(.theme-light-forest):not(.theme-light-mint):not(.theme-light-mauve):not(.theme-light-golden):not(.theme-light-cheery):not(.theme-light-prussian){--primary-color:#ff7096;--secondary-color:#bd93f9;--bg-color:#fff7fa;--light-deep:#e91e63;--light-light:#ffb7cd;--light-lighter:#ffe3ec;--light-pale:#fff0f5;--text-color:#1c1719;--text-color-secondary:#3f3a3b;--link-hover-color:#d81b60;--select-text-bg-color:rgba(255, 112, 150, 0.3);--glow-color:rgba(255, 112, 150, 0.5);--border-color:color-mix(in srgb, var(--primary-color), transparent 60%);--h2-bg-gradient:linear-gradient(to right, var(--light-light), var(--primary-color), var(--light-light));--h2-shadow-color:rgba(61, 184, 211, 0.15);--h2-shadow-hover:rgba(61, 184, 211, 0.35);--text-bold:var(--light-deep);--code-normal:#546e7a;--code-string:#2e7d32;--code-comment:#b0bec5;--code-keyword:#d81b60;--code-function:#8e24aa;--code-value:#f57c00;--code-tag:#d81b60;--code-operator:#8e24aa;--code-property:#00897b;--code-punctuation:#78909c;--code-block-bg:#fff4f8;--code-block-header-bg:color-mix(in srgb, var(--primary-color), transparent 92%)}body.theme-light.theme-light-sky{--primary-color:#3498db;--secondary-color:#5296d5;--bg-color:#f4faff;--light-deep:#1a5276;--light-light:#85c1e9;--light-lighter:#aed6f1;--light-pale:#ebf5fb;--text-color:#080d12;--text-color-secondary:#0a1112;--link-hover-color:#2980b9;--select-text-bg-color:rgba(52, 152, 219, 0.25);--glow-color:rgba(52, 152, 219, 0.5);--code-block-bg:var(--light-pale);--border-color:color-mix(in srgb, var(--primary-color), transparent 60%);--h2-bg-gradient:linear-gradient(to right, var(--light-light), var(--primary-color), var(--light-light));--h2-shadow-color:rgba(52, 152, 219, 0.15);--h2-shadow-hover:rgba(52, 152, 219, 0.35);--text-bold:var(--light-deep);--code-normal:#24292e;--code-keyword:#d73a49;--code-function:#6f42c1;--code-string:#032f62;--code-value:#005cc5;--code-comment:#6a737d;--code-tag:#22863a;--code-operator:#d73a49;--code-property:#005cc5;--code-punctuation:#24292e;--code-block-header-bg:color-mix(in srgb, var(--primary-color), transparent 94%)}body.theme-light.theme-light-forest{--primary-color:#11aa63;--secondary-color:#14ae9c;--bg-color:#f2f9f5;--light-deep:#008145;--light-light:#43bd84;--light-lighter:#68eaad;--light-pale:#f9fffb;--text-color:#000000;--text-color-secondary:#5c7066;--link-hover-color:#009a52;--select-text-bg-color:rgba(17, 170, 99, 0.25);--glow-color:rgba(17, 170, 99, 0.5);--code-block-bg:var(--light-pale);--border-color:color-mix(in srgb, var(--primary-color), transparent 60%);--h2-bg-gradient:linear-gradient(to right, var(--light-light), var(--light-lighter), var(--light-light));--h2-shadow-color:rgba(17, 170, 99, 0.15);--h2-shadow-hover:rgba(17, 170, 99, 0.35);--text-bold:var(--light-deep);--code-normal:#383a42;--code-keyword:#a626a4;--code-function:#4078f2;--code-string:#50a14f;--code-value:#986801;--code-comment:#9ca0a4;--code-tag:#e45649;--code-operator:#0184bc;--code-property:#4078f2;--code-punctuation:#383a42;--code-block-header-bg:color-mix(in srgb, var(--primary-color), transparent 94%)}body.theme-light.theme-light-forest h2{text-shadow:0 1px 2px rgba(0, 0, 0, 0.1)}body.theme-light.theme-light-mint{--primary-color:#3db8bf;--secondary-color:#2acd9e;--bg-color:#f4fdff;--light-deep:#089ba3;--light-light:#7aeaf0;--light-lighter:#b2ebf2;--light-pale:#e0f7fa;--text-color:#263238;--text-color-secondary:#546e7a;--link-hover-color:#00838f;--select-text-bg-color:#7aeaf077;--glow-color:rgba(61, 184, 191, 0.4);--border-color:color-mix(in srgb, var(--primary-color), transparent 75%);--h2-bg-gradient:linear-gradient(to right, #80F7C4, #3DB8D3, #80F7C4);--h2-shadow-color:rgba(61, 184, 191, 0.15);--h2-shadow-hover:rgba(61, 184, 191, 0.35);--text-bold:var(--light-deep);--code-normal:#37474f;--code-string:#00695c;--code-comment:#90a4ae;--code-keyword:#0097a7;--code-function:#0277bd;--code-value:#f57f17;--code-tag:#0097a7;--code-operator:#0277bd;--code-property:#00695c;--code-punctuation:#546e7a;--code-block-bg:#f0fcff;--code-block-header-bg:color-mix(in srgb, var(--primary-color), transparent 94%)}body.theme-light.theme-light-mauve{--primary-color:#A06EB4;--secondary-color:#6A3F7A;--bg-color:#FAFAFC;--light-deep:#6A3F7A;--light-light:#D4B6E0;--light-lighter:#F3E5F5;--light-pale:#F3E5F5;--text-color:#4A235A;--text-color-secondary:#6A3F7A;--link-hover-color:#ba68c8;--select-text-bg-color:#f0d7f966;--glow-color:rgba(160, 110, 180, 0.4);--border-color:color-mix(in srgb, var(--primary-color), transparent 75%);--h2-bg-gradient:linear-gradient(to right, #D8B4E2, #A06EB4, #D8B4E2);--h2-shadow-color:rgba(160, 110, 180, 0.15);--h2-shadow-hover:rgba(160, 110, 180, 0.35);--text-bold:var(--light-deep);--code-background:#F2EFF9;--code-normal:#5E35B1;--code-normal:#4a148c;--code-string:#2e7d32;--code-comment:#9fa8da;--code-keyword:#ba68c8;--code-function:#7b1fa2;--code-value:#f57c00;--code-tag:#ba68c8;--code-operator:#7b1fa2;--code-punctuation:#6a1b9a;--code-block-bg:#fcfbfd;--code-block-header-bg:color-mix(in srgb, var(--primary-color), transparent 94%)}body.theme-light.theme-light-golden{--primary-color:#f59e0b;--secondary-color:#b45309;--bg-color:#fffbeb;--light-deep:#b45309;--light-light:#fbbf24;--light-lighter:#fef3c7;--light-pale:#fffbeb;--text-color:#78350f;--text-color-secondary:#92400e;--link-hover-color:#f59e0b;--select-text-bg-color:#f59e0b33;--glow-color:rgba(245, 158, 11, 0.4);--border-color:color-mix(in srgb, var(--primary-color), transparent 75%);--h2-bg-gradient:linear-gradient(to right, #fcd34d, #f59e0b, #fcd34d);--h2-shadow-color:rgba(245, 158, 11, 0.15);--h2-shadow-hover:rgba(245, 158, 11, 0.35);--text-bold:var(--light-deep);--code-background:#fff7ed;--code-normal:#92400e;--code-normal:#5d4037;--code-string:#689f38;--code-comment:#a1887f;--code-keyword:#d84315;--code-function:#f57f17;--code-value:#e65100;--code-tag:#d84315;--code-operator:#f57f17;--code-punctuation:#8d6e63;--code-block-bg:#fffbf0;--code-block-header-bg:color-mix(in srgb, var(--primary-color), transparent 94%)}body.theme-light.theme-light-cheery{--primary-color:#aa1141;--secondary-color:#810000;--bg-color:#fffbfb;--light-deep:#9a0036;--light-light:#ffa6a6;--light-lighter:#fec2c2;--light-pale:#fffbfb;--text-color:#333333;--text-color-secondary:#870e0e;--link-hover-color:#d81b60;--select-text-bg-color:rgba(123, 123, 123, 0.507);--glow-color:rgba(170, 17, 65, 0.4);--border-color:color-mix(in srgb, var(--primary-color), transparent 75%);--h2-bg-gradient:linear-gradient(to right, #b41919, #ea68b6, #b41919);--h2-shadow-color:rgba(170, 17, 65, 0.15);--h2-shadow-hover:rgba(170, 17, 65, 0.35);--text-bold:var(--light-deep);--code-background:rgb(177 108 108 / 2%);--code-normal:#9a0000;--code-normal:#4a0d18;--code-string:#2e7d32;--code-comment:#8d6e63;--code-keyword:#c2185b;--code-function:#d32f2f;--code-value:#e65100;--code-tag:#c2185b;--code-operator:#d32f2f;--code-punctuation:#870e0e;--code-block-bg:#fff5f7;--code-block-header-bg:color-mix(in srgb, var(--primary-color), transparent 94%)}body.theme-light.theme-light-prussian{--primary-color:#1D4E89;--secondary-color:#003153;--bg-color:#F0F6FA;--light-deep:#003153;--light-light:#6BA3CC;--light-lighter:#E1EDF5;--light-pale:#F0F6FA;--text-color:#003153;--text-color-secondary:#1D4E89;--link-hover-color:#2962ff;--select-text-bg-color:rgba(29, 78, 137, 0.2);--glow-color:rgba(29, 78, 137, 0.4);--border-color:color-mix(in srgb, var(--primary-color), transparent 75%);--h2-bg-gradient:linear-gradient(to right, #6BA3CC, #1D4E89, #6BA3CC);--h2-shadow-color:rgba(29, 78, 137, 0.15);--h2-shadow-hover:rgba(29, 78, 137, 0.35);--text-bold:var(--light-deep);--code-background:#EBF5FA;--code-normal:#0F3057;--code-normal:#37474f;--code-string:#2e7d32;--code-comment:#90a4ae;--code-keyword:#0277bd;--code-function:#006064;--code-value:#e65100;--code-tag:#0277bd;--code-operator:#006064;--code-punctuation:#455a64;--code-block-bg:#f5f9fc;--code-block-header-bg:color-mix(in srgb, var(--primary-color), transparent 94%)}body.theme-light{--glow-shadow-text:0 0 5px var(--glow-color);--glow-shadow-box:0 0 5px var(--glow-color);--background-primary:color-mix(in srgb, var(--bg-color), #fff 2%);--background-card:color-mix(in srgb, var(--primary-color), #FFF calc(var(--bg-mix-percent) * 1%));--background-primary-alt:color-mix(in srgb, var(--bg-color), #000 3%);--background-secondary:color-mix(in srgb, var(--bg-color), #fff 5%);--background-secondary-alt:color-mix(in srgb, var(--bg-color), #000 8%);--text-normal:var(--text-color);--text-muted:var(--text-color-secondary);--mermaid-text-color:var(--text-color);--text-accent:var(--primary-color);--text-accent-hover:var(--link-hover-color);--list-marker-color:var(--primary-color);--interactive-accent:var(--primary-color);--interactive-accent-hover:var(--link-hover-color);--text-selection:#dce3e9b6;--background-modifier-hover:rgba(0, 0, 0, 0.05);--background-modifier-active-hover:rgba(0, 0, 0, 0.1);--background-modifier-border:var(--border-color);--background-modifier-border-hover:var(--secondary-color);--background-modifier-error:#d32f2f;--background-modifier-success:#388e3c;--code-background:var(--code-block-bg);--code-normal:var(--text-color);--input-shadow:inset 0 0 0 1px var(--border-color);--input-shadow-hover:inset 0 0 0 1px var(--secondary-color);--checkbox-bg-unchecked:color-mix(in srgb, var(--primary-color), transparent 90%);--checkbox-border-unchecked:color-mix(in srgb, var(--primary-color), transparent 50%);--checkbox-bg-checked:var(--primary-color);--checkbox-shadow-checked:0 2px 5px color-mix(in srgb, var(--primary-color), transparent 60%);--table-bg:rgba(255, 255, 255, 0.4);--table-border-inner:rgba(0, 0, 0, 0.06);--table-row-hover-bg:rgba(0, 0, 0, 0.03);--table-th-bg:color-mix(in srgb, var(--primary-color), white 90%);--table-th-border:color-mix(in srgb, var(--primary-color), transparent 80%);--table-cell-hover-bg:color-mix(in srgb, var(--primary-color), white 80%);--table-cell-hover-text:var(--primary-color);--border-color:color-mix(in srgb, var(--primary-color), transparent 50%);--blockquote-background-color:color-mix(in srgb, var(--primary-color), white 96%);--setting-items-background:color-mix(in srgb, var(--light-lighter), transparent 94%);--indentation-guide-color:color-mix(in srgb, var(--primary-color), white 50%);--tag-background:color-mix(in srgb, var(--primary-color), white 85%);--tag-background-hover:color-mix(in srgb, var(--primary-color), white 75%);--tag-border-color:color-mix(in srgb, var(--primary-color), white 50%);--tag-border-color-hover:var(--primary-color);--h1-color:var(--h1-light-color, #000000);--h2-color:var(--h2-light-color, #000000);--h3-color:var(--h3-light-color, #000000);--h4-color:var(--h4-light-color, #000000);--h5-color:var(--h5-light-color, #000000);--h6-color:var(--h6-light-color, #000000)}body.theme-dark{--glow-shadow-text:0 0 8px var(--glow-color);--glow-shadow-box:0 0 8px var(--glow-color);--background-primary:var(--bg-color);--background-primary-alt:var(--bg-color);--background-secondary:color-mix(in srgb, var(--bg-color), #000 15%);--background-secondary-alt:color-mix(in srgb, var(--bg-color), #000 25%);--text-normal:var(--text-color);--text-muted:var(--text-color-secondary);--mermaid-text-color:#000;--text-accent:var(--primary-color);--text-accent-hover:var(--link-hover-color);--list-marker-color:var(--primary-color);--interactive-accent:var(--primary-color);--interactive-accent-hover:var(--link-hover-color);--text-selection:var(--select-text-bg-color);--background-modifier-hover:rgba(255, 255, 255, 0.05);--background-modifier-active-hover:rgba(255, 255, 255, 0.1);--background-modifier-border:var(--border-color);--background-modifier-border-hover:var(--secondary-color);--background-modifier-error:#ff5555;--background-modifier-success:#50fa7b;--code-background:var(--code-block-bg);--code-normal:var(--text-color);--checkbox-bg-unchecked:rgba(255, 255, 255, 0.05);--checkbox-border-unchecked:rgba(255, 255, 255, 0.3);--checkbox-bg-checked:color-mix(in srgb, var(--primary-color), transparent 80%);--checkbox-shadow-checked:0 0 8px var(--primary-color);--table-bg:rgba(255, 255, 255, 0.02);--table-border-inner:rgba(255, 255, 255, 0.05);--table-row-hover-bg:rgba(255, 255, 255, 0.03);--table-th-bg:color-mix(in srgb, var(--primary-color), transparent 95%);--table-th-border:color-mix(in srgb, var(--primary-color), transparent 85%);--table-cell-hover-bg:color-mix(in srgb, var(--primary-color), transparent 85%);--table-cell-hover-text:#fff;--setting-items-background:color-mix(in srgb, var(--primary-color), transparent 96%);--tag-background:color-mix(in srgb, var(--primary-color), transparent 85%);--tag-background-hover:color-mix(in srgb, var(--primary-color), transparent 75%);--tag-border-color:color-mix(in srgb, var(--primary-color), transparent 50%);--tag-border-color-hover:var(--primary-color);--h1-color:var(--h1-dark-color, #ffffff);--h2-color:var(--h2-dark-color, #ffffff);--h3-color:var(--h3-dark-color, #ffffff);--h4-color:var(--h4-dark-color, #ffffff);--h5-color:var(--h5-dark-color, #ffffff);--h6-color:var(--h6-dark-color, #ffffff)}body{--line-height-normal:2.2;--line-height-tight:1.3;--line-height-customize:var(--line-height-normal)}.markdown-preview-view,.markdown-source-view{letter-spacing:var(--letter-spacing);position:relative}.markdown-preview-view p,.markdown-preview-view li{color:var(--text-color-secondary);word-spacing:var(--word-spacing)}.markdown-preview-view,.markdown-source-view.mod-cm6 .cm-scroller{line-height:var(--line-height-customize)}body .markdown-preview-view h1,body .markdown-source-view.mod-cm6 .HyperMD-header-1{color:var(--h1-color) !important}body .markdown-preview-view h2,body .markdown-source-view.mod-cm6 .HyperMD-header-2{color:var(--h2-color) !important}body .markdown-preview-view h3,body .markdown-source-view.mod-cm6 .HyperMD-header-3{color:var(--h3-color) !important}body .markdown-preview-view h4,body .markdown-source-view.mod-cm6 .HyperMD-header-4{color:var(--h4-color) !important}body .markdown-preview-view h5,body .markdown-source-view.mod-cm6 .HyperMD-header-5{color:var(--h5-color) !important}body .markdown-preview-view h6,body .markdown-source-view.mod-cm6 .HyperMD-header-6{color:var(--h6-color) !important}.markdown-preview-view h1,.markdown-preview-view h2,.markdown-preview-view h3,.markdown-preview-view h4,.markdown-preview-view h5,.markdown-preview-view h6,.markdown-source-view.mod-cm6 .HyperMD-header{color:var(--text-color);font-weight:bold;position:relative;transition:all 0.3s ease;margin-block-start:var(--heading-spacing);margin-block-end:var(--heading-spacing)}.markdown-preview-view h1{margin-block-start:calc(var(--heading-spacing)*var(--h1-spacing-scale-start));margin-block-end:calc(var(--heading-spacing)*var(--h1-spacing-scale-end))}.markdown-preview-view h2{margin-block-start:calc(var(--heading-spacing)*var(--h2-spacing-scale-start));margin-block-end:calc(var(--heading-spacing)*var(--h2-spacing-scale-end))}.markdown-preview-view h3{margin-block-start:calc(var(--heading-spacing)*var(--h3-spacing-scale-start));margin-block-end:calc(var(--heading-spacing)*var(--h3-spacing-scale-end))}.markdown-preview-view h4{margin-block-start:calc(var(--heading-spacing)*var(--h4-spacing-scale-start));margin-block-end:calc(var(--heading-spacing)*var(--h4-spacing-scale-end))}.markdown-preview-view h5{margin-block-start:calc(var(--heading-spacing)*var(--h5-spacing-scale-start));margin-block-end:calc(var(--heading-spacing)*var(--h5-spacing-scale-end))}.markdown-preview-view h6{margin-block-start:calc(var(--heading-spacing)*var(--h6-spacing-scale-start));margin-block-end:calc(var(--heading-spacing)*var(--h6-spacing-scale-end))}.markdown-source-view.mod-cm6 .HyperMD-header-1{padding-top:calc(var(--heading-spacing)*var(--h1-spacing-scale-start) - 0.25rem);padding-bottom:calc(var(--heading-spacing)*var(--h1-spacing-scale-end) - 0.25rem)}.markdown-source-view.mod-cm6 .HyperMD-header-2{padding-top:calc(var(--heading-spacing)*var(--h2-spacing-scale-start) - 0.25rem);padding-bottom:calc(var(--heading-spacing)*var(--h2-spacing-scale-end) - 0.25rem)}.markdown-source-view.mod-cm6 .HyperMD-header-3{padding-top:calc(var(--heading-spacing)*var(--h3-spacing-scale-start) - 0.25rem);padding-bottom:calc(var(--heading-spacing)*var(--h3-spacing-scale-end) - 0.25rem)}.markdown-source-view.mod-cm6 .HyperMD-header-4{padding-top:calc(var(--heading-spacing)*var(--h4-spacing-scale-start) - 0.25rem);padding-bottom:calc(var(--heading-spacing)*var(--h4-spacing-scale-end) - 0.25rem)}.markdown-source-view.mod-cm6 .HyperMD-header-5{padding-top:calc(var(--heading-spacing)*var(--h5-spacing-scale-start) - 0.25rem);padding-bottom:calc(var(--heading-spacing)*var(--h5-spacing-scale-end) - 0.25rem)}.markdown-source-view.mod-cm6 .HyperMD-header-6{padding-top:calc(var(--heading-spacing)*var(--h6-spacing-scale-start) - 0.25rem);padding-bottom:calc(var(--heading-spacing)*var(--h6-spacing-scale-end) - 0.25rem)}.theme-light .markdown-preview-view .heading-collapse-indicator{margin-inline-start:-47px !important}.theme-dark .markdown-preview-view .heading-collapse-indicator{margin-inline-start:-26px !important}.theme-light .markdown-preview-view h2 .heading-collapse-indicator{margin-inline-start:-19px !important}.theme-dark.h2-style-dark-capsule .markdown-preview-view h2 .heading-collapse-indicator{margin-inline-start:-19px !important}.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2 .heading-collapse-indicator{margin-inline-start:-48px !important}.theme-dark .markdown-preview-view h3 .heading-collapse-indicator,.theme-light .markdown-preview-view h3 .heading-collapse-indicator{margin-inline-start:-43px !important}.theme-dark.h1-align-left .markdown-preview-view h1 .heading-collapse-indicator,.theme-light.h1-align-left .markdown-preview-view h1 .heading-collapse-indicator{margin-inline-start:-50px !important}.markdown-source-view.mod-cm6 .cm-fold-indicator .collapse-indicator{inset-inline-end:22px}.h1-align-left .markdown-source-view.mod-cm6 .cm-fold-indicator .collapse-indicator{inset-inline-end:32px}.theme-light.h2-style-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2 .collapse-indicator,.theme-dark.h2-style-dark-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2 .collapse-indicator{inset-inline-end:-2px}.theme-light.h2-style-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2 .collapse-indicator svg,.theme-dark.h2-style-dark-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2 .collapse-indicator svg,.theme-light.h2-style-capsule .markdown-preview-view h2 .heading-collapse-indicator svg,.theme-dark.h2-style-dark-capsule .markdown-preview-view h2 .heading-collapse-indicator svg{color:#eee}.theme-light .markdown-preview-view h1,.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-1{font-weight:700;line-height:1.4;padding-bottom:12px;display:table;width:auto;min-width:120px;text-align:center;margin-left:auto !important;margin-right:auto !important;position:relative;transition:color 0.3s ease, transform 0.3s ease}.theme-light .markdown-preview-view h1::after,.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-1::after{content:'';position:absolute;bottom:0;left:50%;width:40px;height:4px;border-radius:4px;background:var(--h2-bg-gradient);background-size:100% auto;transform:translateX(-50%);transition:width 0.3s cubic-bezier(0.4, 0, 0.2, 1), transform 0.3s ease}.theme-light .markdown-preview-view h1:hover{color:var(--primary-color);transform:translateY(-2px)}.theme-light .markdown-preview-view h1:hover::after{width:100%}.theme-light.h1-align-left .markdown-preview-view h1,.theme-light.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1{text-align:left;margin-left:0 !important;margin-right:auto !important;padding-left:32px}.theme-light.h1-align-left .markdown-preview-view h1::before,.theme-light.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1::before{content:"";position:absolute;width:10px;height:22px;border-radius:6px;top:45%;transform:translateY(-50%);margin-top:-6px;left:2px;background-color:var(--secondary-color);opacity:0.5;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1);z-index:0}.theme-light.h1-align-left .markdown-preview-view h1::after,.theme-light.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1::after{bottom:auto;width:10px;height:22px;border-radius:6px;top:45%;transform:translateY(-50%);margin-top:4px;left:8px;background:var(--primary-color);mix-blend-mode:multiply;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.05s;z-index:1}.theme-light.h1-align-left .markdown-preview-view h1:hover{transform:none;color:var(--primary-color)}.theme-light.h1-align-left .markdown-preview-view h1:hover::before{height:32px;margin-top:0;left:4px;width:6px;opacity:0.3;border-radius:3px}.theme-light.h1-align-left .markdown-preview-view h1:hover::after{height:26px;margin-top:0;left:12px;width:6px;border-radius:3px;box-shadow:0 0 10px color-mix(in srgb, var(--primary-color), transparent 60%)}.theme-light.h2-style-capsule .markdown-preview-view h2,.theme-light.h2-style-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2{color:#fff !important;font-weight:bold;text-decoration:none !important;display:inline-block;width:fit-content;padding:6px 16px;border-radius:8px;background-image:var(--h2-bg-gradient) !important;background-size:200% auto;background-position:0% center;background-repeat:no-repeat;box-shadow:0 2px 5px var(--h2-shadow-color);border:1px solid transparent !important;background-clip:padding-box;overflow:hidden;border-bottom:none !important;transition:background-position 0.5s ease-out, transform 0.4s ease, box-shadow 0.4s ease}.theme-light.h2-style-capsule .markdown-preview-view h2:hover{background-position:100% center;transform:scale(1.01);box-shadow:0 8px 20px var(--h2-shadow-hover)}.theme-light.h2-style-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2 .cm-formatting-header{color:rgba(255, 255, 255, 0.6) !important}.theme-light:not(.h2-style-capsule) .markdown-preview-view h2,.theme-light.h2-style-twin .markdown-preview-view h2,.theme-light:not(.h2-style-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2,.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2{background:none !important;box-shadow:none !important;border:none !important;border-radius:0 !important;position:relative;padding-left:20px;padding-right:0;display:block;width:100%;transition:color 0.3s ease}.theme-light:not(.h2-style-capsule) .markdown-preview-view h2 .heading-collapse-indicator,.theme-light.h2-style-twin .markdown-preview-view h2 .heading-collapse-indicator{margin-inline-start:-43px !important}.theme-light:not(.h2-style-capsule) .markdown-preview-view h2::before,.theme-light.h2-style-twin .markdown-preview-view h2::before,.theme-light:not(.h2-style-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2::before,.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2::before{content:"";position:absolute;left:0;top:auto;margin-top:0.1em;height:1em;width:5px;background-color:var(--primary-color);border-radius:4px;opacity:1;transition:all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1)}.theme-light:not(.h2-style-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2::before,.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2::before{margin-top:0.2em}.theme-light:not(.h2-style-capsule) .markdown-preview-view h2::after,.theme-light.h2-style-twin .markdown-preview-view h2::after,.theme-light:not(.h2-style-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2::after,.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2::after{content:"";position:absolute;left:8px;top:auto;margin-top:0.3em;height:0.6em;width:2px;background-color:var(--secondary-color);border-radius:2px;opacity:0.6;transition:all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1) 0.05s}.theme-light:not(.h2-style-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2::after,.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2::after{margin-top:0.4em}.theme-light:not(.h2-style-capsule) .markdown-preview-view h2:hover,.theme-light.h2-style-twin .markdown-preview-view h2:hover{color:var(--primary-color) !important}.theme-light:not(.h2-style-capsule) .markdown-preview-view h2:hover::before,.theme-light.h2-style-twin .markdown-preview-view h2:hover::before{top:auto;margin-top:0em;height:1.4em;opacity:0.4}.theme-light:not(.h2-style-capsule) .markdown-preview-view h2:hover::after,.theme-light.h2-style-twin .markdown-preview-view h2:hover::after{top:auto;margin-top:0.15em;height:1.1em;width:4px;opacity:1;background-color:var(--primary-color)}.theme-light:not(.h2-style-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2 .cm-formatting-header,.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2 .cm-formatting-header{color:var(--text-faint) !important;opacity:0.4}.theme-light .markdown-preview-view h3{width:fit-content;padding-left:15px;transition:all 0.3s cubic-bezier(.25, .8, .25, 1)}.theme-light .markdown-preview-view h3::before{content:'';position:absolute;left:0;top:50%;transform:translateY(-50%);width:5px;height:1.3rem;border-radius:4px;background-color:var(--primary-color);transition:all .3s cubic-bezier(.25, .8, .25, 1)}.theme-light .markdown-preview-view h3:hover{padding-left:20px;color:var(--primary-color)}.theme-light .markdown-preview-view h3:hover::before{height:24px;width:7px}.theme-light .markdown-preview-view h4{padding-left:20px}.theme-light .markdown-preview-view h4::before{content:"";position:absolute;left:0;top:50%;transform:translateY(-50%);width:10px;height:10px;border-radius:50%;background-color:var(--primary-color);border:1px solid var(--primary-color);transition:all .3s ease}.theme-light .markdown-preview-view h4:hover{color:var(--light-deep);transform:translateX(6px)}.theme-light .markdown-preview-view h4:hover::before{transform:translateY(-50%) scale(1.3);box-shadow:0 0 0 4px var(--light-lighter)}.theme-light .markdown-preview-view h5{padding-left:20px}.theme-light .markdown-preview-view h5::before{content:"";position:absolute;left:0;top:50%;transform:translateY(-50%);width:10px;height:10px;border-radius:50%;background-color:#fff;border:2px solid var(--primary-color);box-sizing:border-box;transition:all .3s ease}.theme-light .markdown-preview-view h5:hover{color:var(--light-deep);transform:translateX(6px)}.theme-light .markdown-preview-view h5:hover::before{background-color:var(--primary-color);transform:translateY(-50%) scale(1.2);box-shadow:0 0 0 3px var(--light-lighter)}.theme-light .markdown-preview-view h6{padding-left:20px}.theme-light .markdown-preview-view h6::before{content:"-";position:absolute;left:0;top:50%;transform:translateY(-50%);color:var(--primary-color);font-weight:bold;line-height:1;transition:all .3s ease}.theme-light .markdown-preview-view h6:hover{color:var(--light-deep);transform:translateX(6px)}.theme-light .markdown-preview-view h6:hover::before{transform:translateY(-50%) scaleX(1.8)}.theme-dark .markdown-preview-view h1,.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-1{padding-bottom:12px;border-bottom:none;display:table;width:auto;min-width:120px;text-align:center;margin-top:2em;margin-bottom:1em;margin-left:auto !important;margin-right:auto !important;position:relative}.h1-align-left .markdown-preview-view h1{padding-bottom:0;}.theme-dark .markdown-preview-view h1::after,.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-1::after{content:'';position:absolute;bottom:0;left:50%;width:40px;height:4px;border-radius:4px;background:var(--h1-underline-color);box-shadow:0 0 5px rgba(255, 85, 85, 0.4);transform:translateX(-50%);transition:width 0.3s cubic-bezier(0.4, 0, 0.2, 1);pointer-events:none}.theme-dark .markdown-preview-view h1:hover{text-shadow:var(--glow-shadow-text)}.theme-dark .markdown-preview-view h1:hover::after{width:100%;box-shadow:0 0 15px var(--h1-underline-color)}.theme-dark.h1-align-left .markdown-preview-view h1,.theme-dark.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1{text-align:left;margin-left:0 !important;margin-right:auto !important;padding-left:32px}.theme-dark.h1-align-left .markdown-preview-view h1::before,.theme-dark.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1::before{content:"";position:absolute;top:45%;transform:translateY(-50%);margin-top:-6px;left:2px;width:10px;height:22px;border-radius:6px;background-color:var(--secondary-color);opacity:0.6;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1);z-index:0}.theme-dark.h1-align-left .markdown-preview-view h1::after,.theme-dark.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1::after{bottom:auto;top:45%;transform:translateY(-50%);margin-top:4px;left:8px;width:10px;height:22px;border-radius:6px;background:var(--primary-color);mix-blend-mode:screen;transition:all 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.05s;z-index:1}.theme-dark.h1-align-left .markdown-preview-view h1:hover{text-shadow:var(--glow-shadow-text)}.theme-dark.h1-align-left .markdown-preview-view h1:hover::before{height:32px;margin-top:0;left:4px;width:6px;opacity:0.4}.theme-dark.h1-align-left .markdown-preview-view h1:hover::after{height:26px;margin-top:0;left:12px;width:6px;box-shadow:0 0 15px var(--primary-color)}.theme-dark.h2-style-dark-capsule .markdown-preview-view h2,.theme-dark.h2-style-dark-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2{width:fit-content;padding:5px 16px;border-radius:8px;display:inline-block;background-color:rgba(255, 255, 255, 0.02);background-image:var(--h2-bg-image);background-repeat:no-repeat;background-position:center bottom;backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);border-top:1px solid rgba(255, 255, 255, 0.08);border-left:1px solid transparent;border-right:1px solid transparent;border-bottom:1px solid transparent;position:relative;z-index:1;overflow:hidden;transition:color 0.5s ease, transform 0.5s ease, box-shadow 0.5s ease}.theme-dark.h2-style-dark-capsule .markdown-preview-view h2::after,.theme-dark.h2-style-dark-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2::after{content:"";position:absolute;inset:0;z-index:-1;background-image:var(--h2-bg-image-hover);background-repeat:no-repeat;background-position:center bottom;opacity:0;transition:opacity 0.5s ease}.theme-dark.h2-style-dark-capsule .markdown-preview-view h2:hover{color:var(--primary-color);text-shadow:var(--glow-shadow-text);box-shadow:0 4px 12px rgba(0, 0, 0, 0.3);transform:translateY(-1px)}.theme-dark.h2-style-dark-capsule .markdown-preview-view h2:hover::after{opacity:1}.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2,.theme-dark.h2-style-dark-twin .markdown-preview-view h2,.theme-dark:not(.h2-style-dark-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2,.theme-dark.h2-style-dark-twin .markdown-source-view.mod-cm6 .HyperMD-header-2{background:none !important;box-shadow:none !important;border:none !important;border-radius:0 !important;backdrop-filter:none !important;-webkit-backdrop-filter:none !important;position:relative;padding-left:20px;padding-right:0;display:block;width:100%;transition:color 0.3s ease}.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2::before,.theme-dark.h2-style-dark-twin .markdown-preview-view h2::before,.theme-dark:not(.h2-style-dark-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2::before,.theme-dark.h2-style-dark-twin .markdown-source-view.mod-cm6 .HyperMD-header-2::before{content:"";position:absolute;left:0;top:auto;margin-top:0.2em;height:1em;width:5px;background-color:var(--primary-color);border-radius:4px;opacity:0.8;box-shadow:0 0 8px color-mix(in srgb, var(--primary-color), transparent 50%);transition:all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1)}.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2::after,.theme-dark.h2-style-dark-twin .markdown-preview-view h2::after,.theme-dark:not(.h2-style-dark-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2::after,.theme-dark.h2-style-dark-twin .markdown-source-view.mod-cm6 .HyperMD-header-2::after{content:"";position:absolute;left:8px;top:auto;margin-top:0.4em;height:0.6em;width:2px;background-color:var(--secondary-color);border-radius:2px;opacity:0.6;transition:all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1) 0.05s}.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2:hover,.theme-dark.h2-style-dark-twin .markdown-preview-view h2:hover{color:var(--primary-color) !important;text-shadow:var(--glow-shadow-text)}.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2:hover::before,.theme-dark.h2-style-dark-twin .markdown-preview-view h2:hover::before{top:auto;margin-top:0em;height:1.4em;opacity:0.5}.theme-dark:not(.h2-style-dark-capsule) .markdown-preview-view h2:hover::after,.theme-dark.h2-style-dark-twin .markdown-preview-view h2:hover::after{top:auto;margin-top:0.15em;height:1.1em;width:4px;opacity:1;background-color:var(--primary-color);box-shadow:0 0 12px var(--primary-color)}.theme-dark .markdown-preview-view h3{padding-left:15px;display:block;transition:padding-left 0.3s ease, color 0.3s ease}.theme-dark .markdown-preview-view h3::before{content:'';position:absolute;left:0;top:50%;transform:translateY(-50%);width:4px;height:1.3rem;background:var(--primary-color);border-radius:2px;transition:all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);opacity:0.8}.theme-dark .markdown-preview-view h3:hover{color:var(--primary-color);padding-left:20px;text-shadow:var(--glow-shadow-text)}.theme-dark .markdown-preview-view h3:hover::before{height:24px;opacity:1;box-shadow:var(--glow-shadow-box)}.theme-dark .markdown-preview-view h4{display:flex;align-items:center}.theme-dark .markdown-preview-view h4::before{content:"";margin-right:10px;display:inline-block;background-color:var(--primary-color);width:8px;height:8px;border-radius:50%;transition:all 0.3s ease;flex-shrink:0}.theme-dark .markdown-preview-view h4:hover{color:var(--primary-color);text-shadow:var(--glow-shadow-text);transform:translateX(5px)}.theme-dark .markdown-preview-view h4:hover::before{transform:scale(1.2);box-shadow:var(--glow-shadow-box)}.theme-dark .markdown-preview-view h5{display:flex;align-items:center}.theme-dark .markdown-preview-view h5::before{content:"";margin-right:10px;display:inline-block;background-color:transparent;border:1.5px solid var(--primary-color);width:8px;height:8px;border-radius:50%;box-sizing:border-box;transition:all 0.3s ease;flex-shrink:0}.theme-dark .markdown-preview-view h5:hover{color:var(--primary-color);text-shadow:var(--glow-shadow-text);transform:translateX(5px)}.theme-dark .markdown-preview-view h5:hover::before{background-color:transparent;border-color:var(--primary-color);box-shadow:var(--glow-shadow-box);transform:scale(1.2)}.theme-dark .markdown-preview-view h6{display:flex;align-items:center}.theme-dark .markdown-preview-view h6::before{content:"-";color:var(--primary-color);margin-right:11px;display:inline-block;font-weight:bold;transition:all 0.3s ease}.theme-dark .markdown-preview-view h6:hover{color:var(--primary-color);text-shadow:var(--glow-shadow-text);transform:translateX(5px)}.theme-dark .markdown-preview-view h6:hover::before{text-shadow:var(--glow-shadow-text);transform:scaleX(1.5)}.markdown-preview-view h3::after,.markdown-preview-view h4::after,.markdown-preview-view h5::after,.markdown-preview-view h6::after{content:" ";display:inline-block;height:1.2em;width:1.2em;vertical-align:top;margin-left:8px;background-color:var(--primary-color);-webkit-mask-repeat:no-repeat;-webkit-mask-position:center;-webkit-mask-size:contain;mask-repeat:no-repeat;mask-position:center;mask-size:contain;opacity:0.5}.theme-light h3::after,.theme-light h4::after,.theme-light h5::after,.theme-light h6::after{background-color:var(--light-light) !important;opacity:0.5}.markdown-preview-view h3::after{-webkit-mask-image:var(--h3-icon-shape);mask-image:var(--h3-icon-shape)}.markdown-preview-view h4::after{-webkit-mask-image:var(--h4-icon-shape);mask-image:var(--h4-icon-shape)}.markdown-preview-view h5::after{-webkit-mask-image:var(--h5-icon-shape);mask-image:var(--h5-icon-shape)}.markdown-preview-view h6::after{-webkit-mask-image:var(--h6-icon-shape);mask-image:var(--h6-icon-shape)}.markdown-source-view.mod-cm6 .HyperMD-header{font-weight:bold;line-height:1.4;position:relative}.markdown-source-view.mod-cm6 .cm-formatting-header{color:var(--primary-color);font-family:var(--font-monospace);font-weight:normal;margin-right:8px;opacity:0.4}.markdown-source-view.mod-cm6 .HyperMD-header-1{text-align:center;justify-content:center;border-bottom:none}.markdown-source-view.mod-cm6 .HyperMD-header-1::after{content:"";display:block;width:40px;height:4px;border-radius:4px;background:var(--primary-color);background-image:var(--h2-bg-gradient, linear-gradient(to right, var(--primary-color), var(--primary-color)));margin:8px auto 0 auto;opacity:0.8}.markdown-source-view.mod-cm6 .HyperMD-header-3{padding-left:20px}.markdown-source-view.mod-cm6 .HyperMD-header-3::before{content:"";position:absolute;margin-top:0.3rem;left:0;width:5px;height:1.3rem;border-radius:4px;background-color:var(--primary-color);opacity:0.8;pointer-events:none}.markdown-source-view.mod-cm6 .HyperMD-header-4{padding-left:20px}.markdown-source-view.mod-cm6 .HyperMD-header-4::before{content:"";position:absolute;margin-top:0.46rem;left:0;width:10px;height:10px;border-radius:50%;background-color:var(--primary-color);border:1px solid var(--primary-color);pointer-events:none}.markdown-source-view.mod-cm6 .HyperMD-header-5{padding-left:20px}.markdown-source-view.mod-cm6 .HyperMD-header-5::before{content:"";position:absolute;margin-top:0.5rem;left:0;width:10px;height:10px;border-radius:50%;background-color:transparent;border:2px solid var(--primary-color);box-sizing:border-box;background-color:var(--bg-color, transparent);pointer-events:none}.markdown-source-view.mod-cm6 .HyperMD-header-6{padding-left:20px}.markdown-source-view.mod-cm6 .HyperMD-header-6::before{content:"-";position:absolute;left:0;color:var(--primary-color);font-weight:bold;line-height:1.4;font-family:var(--font-monospace);pointer-events:none}.markdown-source-view.mod-cm6 .HyperMD-header:hover::before{opacity:1;border-color:var(--primary-color)}.markdown-source-view.mod-cm6 .HyperMD-header-3::after,.markdown-source-view.mod-cm6 .HyperMD-header-4::after,.markdown-source-view.mod-cm6 .HyperMD-header-5::after,.markdown-source-view.mod-cm6 .HyperMD-header-6::after{content:"";display:inline-block;vertical-align:top;width:1.2em;height:1.2em;margin-left:8px;background-color:var(--primary-color);-webkit-mask-repeat:no-repeat;-webkit-mask-position:center;-webkit-mask-size:contain;mask-repeat:no-repeat;mask-position:center;mask-size:contain;opacity:0.3;pointer-events:none}.markdown-source-view.mod-cm6 .HyperMD-header-3::after{-webkit-mask-image:var(--h3-icon-shape);mask-image:var(--h3-icon-shape)}.markdown-source-view.mod-cm6 .HyperMD-header-4::after{-webkit-mask-image:var(--h4-icon-shape);mask-image:var(--h4-icon-shape)}.markdown-source-view.mod-cm6 .HyperMD-header-5::after{-webkit-mask-image:var(--h5-icon-shape);mask-image:var(--h5-icon-shape)}.markdown-source-view.mod-cm6 .HyperMD-header-6::after{-webkit-mask-image:var(--h6-icon-shape);mask-image:var(--h6-icon-shape)}.markdown-preview-view ul>li::marker,.markdown-preview-view ol>li::marker{color:var(--primary-color)}.markdown-preview-view em{padding:0 3px 0 0;color:var(--secondary-color)}.markdown-preview-view ul{list-style-type:disc}.markdown-preview-view ul ul{list-style-type:circle}.markdown-preview-view ul ul ul{list-style-type:square}.markdown-preview-view ol{list-style-type:decimal}.markdown-preview-view ol ol{list-style-type:lower-alpha}.markdown-preview-view ol ol ol{list-style-type:lower-roman}.markdown-preview-view ul>li>ol{padding-left:25px}.markdown-preview-view li{position:relative}.markdown-preview-view li::before{content:"";position:absolute;top:calc(var(--line-height-customize) * 1em);height:calc(100% - (var(--line-height-customize) * 1.5em));bottom:0;left:-18px;border-left:1px solid var(--primary-color);opacity:0.5;pointer-events:none}.markdown-preview-view ul>li::before{left:-0.83rem}.markdown-preview-view>div>ul>li::before,.markdown-preview-view>div>ol>li::before{display:none}.markdown-preview-view li.task-list-item::before{left:-0.7rem;height:calc(100% - var(--line-height-customize) * 1.4em)}.markdown-rendered.show-indentation-guide li>ul::before,.markdown-rendered.show-indentation-guide li>ol::before{display:none !important;border:none !important}.el-ol ol li{margin-left:35px}.markdown-source-view.mod-cm6 .HyperMD-list-line{--list-color:var(--text-muted)}.markdown-source-view.mod-cm6 .HyperMD-list-line-1,.markdown-source-view.mod-cm6 .HyperMD-list-line-2,.markdown-source-view.mod-cm6 .HyperMD-list-line-3,.markdown-source-view.mod-cm6 .HyperMD-list-line-4,.markdown-source-view.mod-cm6 .HyperMD-list-line-5,.markdown-source-view.mod-cm6 .HyperMD-list-line-6{--list-color:var(--primary-color)}.markdown-source-view.mod-cm6 .list-bullet{color:transparent !important;position:relative;margin-right:12px !important;display:inline-block}.markdown-source-view.mod-cm6 .list-bullet:after{content:"";position:absolute;top:50%;left:50%;transform:translate(-50%, -50%) scale(1.1);height:6px;width:6px;border-radius:50%;background-color:var(--list-color) !important;transition:all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275)}.markdown-source-view.mod-cm6 .HyperMD-list-line:hover .list-bullet:after{transform:translate(-50%, -50%) scale(1.6);box-shadow:0 0 8px var(--list-color)}.markdown-source-view.is-live-preview{--list-padding-inline-start:0}.markdown-source-view.mod-cm6 .cm-indent::before{margin-inline-start:3px !important}.markdown-source-view.mod-cm6 .cm-active-indent::before{opacity:1 !important;box-shadow:0 0 8px var(--primary-color);z-index:1}.markdown-source-view.mod-cm6 .HyperMD-list-line .task-list-item-checkbox{border-color:var(--list-color) !important}.markdown-source-view.mod-cm6 .HyperMD-list-line .task-list-item-checkbox:checked{background-color:var(--list-color) !important;box-shadow:0 0 5px var(--list-color)}.markdown-source-view.mod-cm6 .list-number{color:var(--primary-color) !important;font-family:"Cascadia Code", "Lucida Console", monospace !important;font-weight:bold;margin-right:4px}.image-embed[alt*="right" i],.image-embed[alt*="+R" i],.image-embed[alt*="left" i],.image-embed[alt*="+L" i],.image-embed[alt*="center" i],.image-embed[alt*="+C" i],.image-embed[alt*="banner" i]{display:flex !important;width:100% !important;margin-top:0.5rem;margin-bottom:0.5rem}.image-embed[alt*="right" i],.image-embed[alt*="+R" i]{justify-content:flex-end}.image-embed[alt*="left" i],.image-embed[alt*="+L" i]{justify-content:flex-start}.image-embed[alt*="center" i],.image-embed[alt*="+C" i]{justify-content:center}.image-embed[alt*="right" i] img,.image-embed[alt*="+R" i] img,.image-embed[alt*="left" i] img,.image-embed[alt*="+L" i] img,.image-embed[alt*="center" i] img,.image-embed[alt*="+C" i] img{border-radius:8px;box-shadow:0 4px 15px rgba(0,0,0,0.05)}.image-embed[alt*="banner" i]{justify-content:center}.image-embed[alt*="banner" i] img{width:100% !important;max-height:250px;object-fit:cover;border-radius:12px;box-shadow:0 4px 15px rgba(0,0,0,0.05)}.markdown-preview-view ul.contains-task-list{margin-left:10px}.markdown-preview-view ul.contains-task-list{margin-left:10px}.markdown-preview-view input[type="checkbox"],.markdown-preview-view .task-list-item-checkbox{-webkit-appearance:none !important;appearance:none !important;background:transparent !important;border:none !important;border-radius:0 !important;outline:none !important;box-shadow:none !important;position:absolute !important;margin:0 !important;padding:0 !important;left:-1.3rem !important;top:calc((var(--line-height-customize) * 1.1rem - var(--checkbox-size)) / 2) !important;width:var(--checkbox-size) !important;height:var(--checkbox-size) !important;z-index:10;-webkit-mask-image:none !important;mask-image:none !important}.markdown-preview-view input[type="checkbox"]::before,.markdown-preview-view .task-list-item-checkbox::before{content:"" !important;display:block !important;position:absolute !important;inset:0 !important;width:1.2rem !important;height:1.2rem !important;border-radius:50% !important;background-color:var(--checkbox-bg-unchecked) !important;border:2px solid var(--checkbox-border-unchecked) !important;box-sizing:border-box !important;transition:all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.4);z-index:1}.markdown-preview-view input[type="checkbox"]:checked::before,.markdown-preview-view .task-list-item-checkbox:checked::before{border:1px solid var(--primary-color) !important;background-color:var(--checkbox-bg-checked) !important;box-shadow:var(--checkbox-shadow-checked) !important;animation:task-pulse 0.4s forwards}.markdown-preview-view input[type="checkbox"]::after,.markdown-preview-view .task-list-item-checkbox::after{content:"" !important;display:block !important;position:absolute !important;z-index:2 !important;top:45% !important;left:50% !important;width:0.45rem !important;height:0.25rem !important;background-color:transparent !important;-webkit-mask-image:none !important;mask-image:none !important;border:2.5px solid var(--checkmark-color) !important;border-top:0 !important;border-right:0 !important;transform:translate(-50%, -50%) rotate(-45deg) scale(0);opacity:0;transition:all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.4)}.markdown-preview-view input[type="checkbox"]:checked::after,.markdown-preview-view .task-list-item-checkbox:checked::after{opacity:1 !important;transform:translate(-50%, -50%) rotate(-45deg) scale(1) !important;border-color:var(--checkmark-color) !important}.markdown-preview-view .task-list-item[data-task="/"]{color:var(--text-normal) !important;text-decoration:none !important;opacity:1 !important}.markdown-preview-view .task-list-item[data-task="/"] p,.markdown-preview-view .task-list-item[data-task="/"] strong,.markdown-preview-view .task-list-item[data-task="/"] em,.markdown-preview-view .task-list-item[data-task="/"] code{text-decoration:none !important;color:inherit !important}.markdown-preview-view .task-list-item[data-task="/"] input[type="checkbox"]:checked::after{content:"" !important;border:none !important;width:6px !important;height:6px !important;border-radius:50% !important;background-color:var(--checkmark-color) !important;top:50% !important;left:50% !important;transform:translate(-50%, -50%) !important}.markdown-preview-view .task-list-item[data-task="-"]{color:var(--text-muted) !important;text-decoration:line-through !important;opacity:0.7 !important}.markdown-preview-view .task-list-item[data-task="-"] strong,.markdown-preview-view .task-list-item[data-task="-"] em{text-decoration:line-through !important;color:inherit !important}.markdown-preview-view .task-list-item[data-task="-"] input[type="checkbox"]:checked::before{background-color:var(--text-muted) !important;border-color:var(--text-muted) !important;box-shadow:none !important}.markdown-preview-view .task-list-item[data-task="-"] input[type="checkbox"]:checked::after{content:"\2715" !important;border:none !important;transform:none !important;background:transparent !important;font-size:13px !important;font-weight:800 !important;color:#ffffff !important;display:flex !important;align-items:center;justify-content:center;width:100% !important;height:100% !important;top:-1px !important;left:-0.3px !important}@keyframes task-pulse{0%{transform:scale(1)}50%{transform:scale(1.15)}100%{transform:scale(1)}}.markdown-preview-view .task-list-item{position:relative;list-style:none;padding-left:4px;min-height:calc(var(--line-height-customize) * 1em);transition:color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),        opacity 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),        text-decoration-color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1) !important;text-decoration:line-through !important;text-decoration-color:transparent !important;text-decoration-thickness:2px !important}.markdown-preview-view .task-list-item.is-checked{color:#888 !important;opacity:0.8;text-decoration-color:var(--text-color-secondary) !important}.markdown-preview-view .task-list-item.is-checked p,.markdown-preview-view .task-list-item.is-checked strong,.markdown-preview-view .task-list-item.is-checked em,.markdown-preview-view .task-list-item.is-checked mark,.markdown-preview-view .task-list-item.is-checked code{text-decoration:line-through !important;text-decoration-color:var(--text-color-secondary) !important;text-decoration-thickness:2px !important;color:inherit !important;opacity:1 !important}.markdown-preview-view blockquote p,.HyperMD-quote.HyperMD-quote-1.cm-line{line-height:var(--blockquote-line-height)}.theme-dark .markdown-preview-view blockquote{position:relative;margin:20px 0;padding:18px 20px 18px 48px;color:var(--text-color-secondary);background-color:rgba(0, 0, 0, 0.2);border:1px solid color-mix(in srgb, var(--secondary-color), transparent 70%);border-radius:16px;transition:all 0.3s ease}.theme-dark .markdown-preview-view blockquote::before{content:"💡";position:absolute;left:14px;top:18px;font-size:20px;line-height:1;filter:grayscale(1);opacity:0.8;transform:rotate(30deg);transition:all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)}.theme-dark .markdown-preview-view blockquote p{color:var(--text-color-secondary);margin-block-start:0;margin-block-end:0;margin-bottom:0.5em}.theme-dark .markdown-preview-view blockquote p:last-child{margin-bottom:0}.theme-dark .markdown-preview-view blockquote:hover{border-color:var(--primary-color);background-color:color-mix(in srgb, var(--hover-background-color), transparent 95%);box-shadow:0 0 15px color-mix(in srgb, var(--hover-background-color), transparent 90%),        inset 0 0 10px color-mix(in srgb, var(--hover-background-color), transparent 95%);transform:scale(1.01)}.theme-dark .markdown-preview-view blockquote:hover::before{filter:grayscale(0);opacity:1;transform:rotate(0deg);text-shadow:0 0 10px var(--primary-color)}.theme-light .markdown-preview-view blockquote{position:relative;margin:20px 0;padding:18px 20px 18px 48px;background-color:var(--blockquote-background-color);border:1px solid color-mix(in srgb, var(--primary-color), transparent 80%);border-radius:16px;color:var(--text-muted);transition:transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),        background-color 0.3s ease,        box-shadow 0.3s ease,        border-color 0.3s ease}.theme-light .markdown-preview-view blockquote::before{content:"✨";position:absolute;left:14px;top:18px;font-size:20px;line-height:1;font-family:"Segoe UI Emoji", "Apple Color Emoji", sans-serif;filter:none;opacity:1;transform:rotate(30deg);transition:all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)}.theme-light .markdown-preview-view blockquote p{color:var(--text-muted);margin-block-start:0;margin-block-end:0;margin-bottom:0.5em}.theme-light .markdown-preview-view blockquote p:last-child{margin-bottom:0}.theme-light .markdown-preview-view blockquote:hover{transform:scale(1.02);background-color:color-mix(in srgb, var(--primary-color), white 92%);border-color:var(--primary-color);box-shadow:0 8px 20px color-mix(in srgb, var(--primary-color), transparent 85%)}.theme-light .markdown-preview-view blockquote:hover::before{transform:rotate(0deg);text-shadow:0 0 8px var(--primary-color)}.markdown-preview-view a.internal-link,.markdown-preview-view a.external-link,.markdown-source-view.mod-cm6 .cm-link .cm-underline,.markdown-source-view.mod-cm6 .cm-table-widget a{color:var(--secondary-color) !important;text-decoration:none !important;font-weight:500;padding:0 2px;margin:0;border-radius:4px;position:relative;border-bottom:none !important;background-image:none !important;padding-right:2px !important;cursor:pointer;transition:all 0.3s ease}.markdown-preview-view a.internal-link::before,.markdown-preview-view a.external-link::before,.markdown-source-view.mod-cm6 .cm-link .cm-underline::before,.markdown-source-view.mod-cm6 .cm-table-widget a::before{content:"[";display:inline-block;color:var(--text-muted);margin-right:1px;opacity:0.7;transition:transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), color 0.3s, opacity 0.3s}.markdown-preview-view a.internal-link::after,.markdown-preview-view a.external-link::after,.markdown-source-view.mod-cm6 .cm-link .cm-underline::after,.markdown-source-view.mod-cm6 .cm-table-widget a::after{content:"]";display:inline-block;color:var(--text-muted);margin-left:1px;opacity:0.7;transition:transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1), color 0.3s, opacity 0.3s}.markdown-preview-view a.internal-link:hover,.markdown-preview-view a.external-link:hover,.markdown-source-view.mod-cm6 .cm-link .cm-underline:hover,.markdown-source-view.mod-cm6 .cm-table-widget a:hover{background-color:color-mix(in srgb, var(--primary-color), transparent 90%);color:var(--primary-color) !important;text-decoration:none !important}.markdown-preview-view a.internal-link:hover::before,.markdown-preview-view a.external-link:hover::before,.markdown-source-view.mod-cm6 .cm-link .cm-underline:hover::before,.markdown-source-view.mod-cm6 .cm-table-widget a:hover::before{transform:translateX(-4px);color:var(--primary-color);font-weight:bold;opacity:1}.markdown-preview-view a.internal-link:hover::after,.markdown-preview-view a.external-link:hover::after,.markdown-source-view.mod-cm6 .cm-link .cm-underline:hover::after,.markdown-source-view.mod-cm6 .cm-table-widget a:hover::after{transform:translateX(4px);color:var(--primary-color);font-weight:bold;opacity:1}.markdown-preview-view .external-link-icon,.markdown-source-view.mod-cm6 .cm-link .external-link,.markdown-source-view.mod-cm6 .cm-formatting-link-string.external-link,.markdown-source-view.mod-cm6 .cm-url.external-link{display:none !important;width:0 !important;height:0 !important;content:none !important;background-image:none !important;padding:0 !important;margin:0 !important}.markdown-preview-view table td a,.markdown-source-view.mod-cm6 .cm-table-widget a{padding:0 2px !important}.markdown-preview-view mark,.markdown-source-view.mod-cm6 mark,.markdown-source-view.mod-cm6 .cm-highlight{padding:0 2px;margin:0;border-radius:4px;font-weight:inherit;color:inherit;-webkit-box-decoration-break:clone;box-decoration-break:clone}.markdown-preview-view mark::before,.markdown-preview-view mark::after,.markdown-source-view.mod-cm6 mark::before,.markdown-source-view.mod-cm6 mark::after,.markdown-source-view.mod-cm6 .cm-highlight::before,.markdown-source-view.mod-cm6 .cm-highlight::after{content:none !important;display:none !important}.markdown-preview-view mark:not([style*="background"]),.markdown-source-view.mod-cm6 mark:not([style*="background"]),.markdown-source-view.mod-cm6 .cm-highlight:not([style*="background"]){background-color:transparent !important;background-repeat:no-repeat;background-position:0 100%;transition:background-size 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),        color 0.3s ease,        text-shadow 0.3s ease,        box-shadow 0.3s ease}body.theme-light .markdown-preview-view mark:not([style*="background"]),body.theme-light .markdown-source-view.mod-cm6 mark:not([style*="background"]),body.theme-light .markdown-source-view.mod-cm6 .cm-highlight:not([style*="background"]){background-image:linear-gradient(to top, color-mix(in srgb, var(--primary-color), transparent 60%), transparent);background-size:100% 40%;color:var(--text-normal)}body.theme-light .markdown-preview-view mark:not([style*="background"]):hover,body.theme-light .markdown-source-view.mod-cm6 mark:not([style*="background"]):hover,body.theme-light .markdown-source-view.mod-cm6 .cm-highlight:not([style*="background"]):hover{background-size:100% 100%;background-image:linear-gradient(to top, color-mix(in srgb, var(--primary-color), transparent 40%), color-mix(in srgb, var(--primary-color), transparent 80%))}body.theme-dark .markdown-preview-view mark:not([style*="background"]),body.theme-dark .markdown-source-view.mod-cm6 mark:not([style*="background"]),body.theme-dark .markdown-source-view.mod-cm6 .cm-highlight:not([style*="background"]){background-image:linear-gradient(to top, color-mix(in srgb, var(--primary-color), transparent 50%), transparent) !important;background-size:100% 40%;color:color-mix(in srgb, var(--primary-color), white 20%) !important;text-shadow:none;box-shadow:none}body.theme-dark .markdown-preview-view mark:not([style*="background"]):hover,body.theme-dark .markdown-source-view.mod-cm6 mark:not([style*="background"]):hover,body.theme-dark .markdown-source-view.mod-cm6 .cm-highlight:not([style*="background"]):hover{background-size:100% 100%;background-image:linear-gradient(to top, color-mix(in srgb, var(--primary-color), transparent 20%), color-mix(in srgb, var(--primary-color), transparent 80%)) !important;color:#fff !important;text-shadow:0 0 10px var(--primary-color);box-shadow:0 0 15px color-mix(in srgb, var(--primary-color), transparent 80%);transform:none}.markdown-preview-view strong,.markdown-source-view.mod-cm6 .cm-strong,.markdown-source-view.mod-cm6 strong{font-weight:bold;display:inline;position:relative;border-bottom:2px solid transparent;-webkit-box-decoration-break:clone;box-decoration-break:clone;transition:border-color 0.3s ease,        color 0.3s ease,        text-shadow 0.3s ease}body.theme-dark .markdown-preview-view strong,body.theme-dark .markdown-source-view.mod-cm6 .cm-strong,body.theme-dark .markdown-source-view.mod-cm6 strong{color:var(--primary-color)}body.theme-dark .markdown-preview-view strong:hover,body.theme-dark .markdown-source-view.mod-cm6 .cm-strong:hover,body.theme-dark .markdown-source-view.mod-cm6 strong:hover{border-bottom-color:var(--primary-color);text-shadow:0 0 10px var(--primary-color);z-index:1}body.theme-light .markdown-preview-view strong,body.theme-light .markdown-source-view.mod-cm6 .cm-strong,body.theme-light .markdown-source-view.mod-cm6 strong{color:var(--text-bold)}body.theme-light .markdown-preview-view strong:hover,body.theme-light .markdown-source-view.mod-cm6 .cm-strong:hover,body.theme-light .markdown-source-view.mod-cm6 strong:hover{color:var(--primary-color) !important;border-bottom-color:color-mix(in srgb, var(--primary-color), transparent 70%);text-shadow:0 2px 10px color-mix(in srgb, var(--primary-color), transparent 60%)}.markdown-preview-view em,.markdown-source-view.mod-cm6 .cm-em,.markdown-source-view.mod-cm6 em{font-style:italic;text-decoration:none !important;padding-bottom:1px;background-repeat:repeat-x;background-position:0 100%;background-size:6px 3px;transition:color 0.2s ease, -webkit-text-stroke 0.2s ease, background-image 0.2s ease;-webkit-box-decoration-break:clone;box-decoration-break:clone}.markdown-preview-view em::after,.markdown-source-view.mod-cm6 .cm-em::after,.markdown-source-view.mod-cm6 em::after{content:none !important;display:none !important}@keyframes stitchFlow{from{background-position-x:0}to{background-position-x:6px}}body.theme-light .markdown-preview-view em,body.theme-light .markdown-source-view.mod-cm6 .cm-em,body.theme-light .markdown-source-view.mod-cm6 em{color:var(--secondary-color);background-image:linear-gradient(-45deg,            transparent 35%,            color-mix(in srgb, var(--secondary-color), transparent 60%) 35%,            color-mix(in srgb, var(--secondary-color), transparent 60%) 65%,            transparent 65%)}body.theme-light .markdown-preview-view em:hover,body.theme-light .markdown-source-view.mod-cm6 .cm-em:hover,body.theme-light .markdown-source-view.mod-cm6 em:hover{color:var(--primary-color);background-image:linear-gradient(-45deg,            transparent 35%,            var(--primary-color) 35%,            var(--primary-color) 65%,            transparent 65%);font-weight:normal;-webkit-text-stroke:0.6px var(--primary-color);animation:stitchFlow 0.5s linear infinite}body.theme-dark .markdown-preview-view em,body.theme-dark .markdown-source-view.mod-cm6 .cm-em,body.theme-dark .markdown-source-view.mod-cm6 em{color:var(--secondary-color);background-image:linear-gradient(-45deg,            transparent 35%,            color-mix(in srgb, var(--secondary-color), white 20%) 35%,            color-mix(in srgb, var(--secondary-color), white 20%) 65%,            transparent 65%)}body.theme-dark .markdown-preview-view em:hover,body.theme-dark .markdown-source-view.mod-cm6 .cm-em:hover,body.theme-dark .markdown-source-view.mod-cm6 em:hover{color:var(--primary-color);background-image:linear-gradient(-45deg,            transparent 35%,            var(--primary-color) 35%,            var(--primary-color) 65%,            transparent 65%);font-weight:normal;-webkit-text-stroke:0.5px var(--primary-color);text-shadow:var(--glow-shadow-text);animation:stitchFlow 0.5s linear infinite}.markdown-preview-view s,.markdown-preview-view del,.markdown-source-view.mod-cm6 .cm-strikethrough{text-decoration:line-through;transition:all 0.3s ease}body.theme-dark .markdown-preview-view s,body.theme-dark .markdown-preview-view del,body.theme-dark .markdown-source-view.mod-cm6 .cm-strikethrough{text-decoration-color:var(--primary-color);color:#888}body.theme-dark .markdown-preview-view s:hover,body.theme-dark .markdown-preview-view del:hover,body.theme-dark .markdown-source-view.mod-cm6 .cm-strikethrough:hover{opacity:1;color:var(--primary-color) !important;text-decoration-color:var(--secondary-color);cursor:not-allowed;text-shadow:0 0 8px var(--primary-color)}body.theme-light .markdown-preview-view s,body.theme-light .markdown-preview-view del,body.theme-light .markdown-source-view.mod-cm6 .cm-strikethrough{text-decoration-color:color-mix(in srgb, var(--primary-color), transparent 40%);color:#999}body.theme-light .markdown-preview-view s:hover,body.theme-light .markdown-preview-view del:hover,body.theme-light .markdown-source-view.mod-cm6 .cm-strikethrough:hover{opacity:1;color:var(--text-normal) !important;text-decoration-color:#ff5555;cursor:not-allowed;text-shadow:none}.markdown-preview-view hr{border:none;height:1px;background:linear-gradient(90deg, transparent, var(--primary-color), transparent);position:relative;overflow:visible;opacity:0.5;transition:all 0.3s ease}.markdown-preview-view hr::after{content:'';position:absolute;left:50%;top:50%;transform:translate(-50%, -50%) rotate(45deg);width:8px;height:8px;border:2px solid var(--primary-color);background-color:var(--bg-color);box-sizing:border-box;transition:all 0.3s ease}.markdown-preview-view hr:hover{opacity:1;background:linear-gradient(90deg, transparent, var(--primary-color), transparent)}.markdown-preview-view hr:hover::after{border-color:var(--primary-color);background-color:var(--primary-color);box-shadow:0 0 10px var(--primary-color);transform:translate(-50%, -50%) rotate(225deg) scale(1.5)}.markdown-preview-view table{border-collapse:separate !important;border-spacing:0 !important;width:100%;margin:1.5em 0;border:1px solid var(--border-color);border-radius:var(--table-border-radius);overflow:hidden;background-color:var(--table-bg);backdrop-filter:blur(5px);-webkit-backdrop-filter:blur(5px);line-height:var(--table-line-height)}.markdown-preview-view table th,.markdown-preview-view table td{padding:10px 15px;color:var(--text-color);border-top:none !important;border-left:none !important;border-right:1px solid var(--table-border-inner);border-bottom:1px solid var(--table-border-inner);transition:all 0.2s ease}.markdown-preview-view table th:last-child,.markdown-preview-view table td:last-child{border-right:none !important}.markdown-preview-view table tr:last-child td{border-bottom:none !important}.markdown-preview-view table th{background-color:var(--table-th-bg) !important;color:var(--primary-color);font-weight:bold;white-space:nowrap;border-right:1px solid var(--table-th-border) !important;border-bottom:1px solid var(--table-th-border) !important}.markdown-preview-view table th:last-child{border-right:none !important}.markdown-preview-view table tbody tr:hover td{background-color:var(--table-row-hover-bg)}.markdown-preview-view table tbody td:hover{background-color:var(--table-cell-hover-bg);color:var(--table-cell-hover-text);box-shadow:inset 0 0 0 1px var(--primary-color);cursor:default}.markdown-preview-view table tr:nth-child(2n),.markdown-preview-view table tr:nth-child(2n+1){background-color:transparent !important}.markdown-preview-view table thead tr,.markdown-preview-view table thead tr:nth-child(2n),.markdown-preview-view table thead tr:nth-child(2n+1){background-color:transparent !important}.markdown-preview-view table th{background-color:var(--table-th-bg) !important}.theme-dark .markdown-preview-view table tbody td:hover{text-shadow:0 0 8px var(--primary-color)}.theme-light .markdown-preview-view table tbody td:hover{text-shadow:none}.markdown-source-view.mod-cm6 .cm-table-widget .table-editor{background-color:var(--table-bg) !important;border:1px solid var(--border-color) !important;border-radius:var(--table-border-radius);border-collapse:separate !important;margin-top:1em;margin-bottom:1em;width:100%}.markdown-source-view.mod-cm6 .cm-table-widget thead th{background-color:var(--table-th-bg) !important;color:var(--primary-color) !important;font-weight:bold;border-bottom:1px solid var(--table-th-border) !important;border-right:1px solid var(--table-th-border) !important;border-top:none !important;border-left:none !important;position:relative}.markdown-source-view.mod-cm6 .cm-table-widget tbody td{border-right:1px solid var(--table-border-inner) !important;border-bottom:1px solid var(--table-border-inner) !important;border-top:none !important;border-left:none !important;color:var(--text-color);transition:background-color 0.2s ease}.markdown-source-view.mod-cm6 .cm-table-widget .table-cell-wrapper{padding:10px 15px !important;display:block;min-height:100%}.markdown-source-view.mod-cm6 .cm-table-widget th:last-child,.markdown-source-view.mod-cm6 .cm-table-widget td:last-child{border-right:none !important}.markdown-source-view.mod-cm6 .cm-table-widget tbody tr:last-child td{border-bottom:none !important}.markdown-source-view.mod-cm6 .cm-table-widget tbody tr:hover td{background-color:var(--table-row-hover-bg)}.markdown-source-view.mod-cm6 .cm-table-widget tbody td:hover{background-color:var(--table-cell-hover-bg) !important;box-shadow:inset 0 0 0 1px var(--primary-color) !important}.markdown-source-view.mod-cm6 .cm-table-widget .table-col-drag-handle,.markdown-source-view.mod-cm6 .cm-table-widget .table-row-drag-handle{opacity:0;transition:opacity 0.2s ease;background-color:color-mix(in srgb, var(--border-color), transparent 70%)}.markdown-source-view.mod-cm6 .cm-table-widget th:hover .table-col-drag-handle,.markdown-source-view.mod-cm6 .cm-table-widget th:hover .table-row-drag-handle,.markdown-source-view.mod-cm6 .cm-table-widget td:hover .table-row-drag-handle{opacity:1}.markdown-source-view.mod-cm6 .cm-table-widget .table-row-btn,.markdown-source-view.mod-cm6 .cm-table-widget .table-col-btn{color:var(--text-muted);transition:all 0.2s ease;background-color:transparent}.markdown-source-view.mod-cm6 .cm-table-widget .table-row-btn{width:97%}.markdown-source-view.mod-cm6 .cm-table-widget .table-row-btn:hover,.markdown-source-view.mod-cm6 .cm-table-widget .table-col-btn:hover{border:none;color:var(--primary-color);background-color:transparent;transform:scale(1.1)}.markdown-source-view.mod-cm6 .cm-table-widget .cm-active{background-color:transparent !important}.markdown-rendered button.copy-code-button{top:-4px}.markdown-preview-view pre{position:relative;background-color:var(--code-background) !important;border:1px solid color-mix(in srgb, var(--border-color), transparent 50%) !important;border-radius:var(--code-radius);padding-top:38px !important;padding-bottom:12px;padding-left:0;padding-right:0;margin:20px 0;overflow:hidden;transition:border-color 0.3s ease, box-shadow 0.3s ease}.markdown-preview-view pre:hover{border-color:var(--primary-color) !important;box-shadow:0 4px 12px color-mix(in srgb, var(--primary-color), transparent 85%)}.markdown-preview-view pre::before{content:"";position:absolute;top:0;left:0;width:100%;height:32px;background-color:color-mix(in srgb, var(--primary-color), transparent 96%);background-image:url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iNDUwcHgiIGhlaWdodD0iMTMwcHgiPgogIDxlbGxpcHNlIGN4PSI2NSIgY3k9IjY1IiByeD0iNTAiIHJ5PSI1MiIgc3Ryb2tlPSJyZ2IoMjIwLDYwLDU0KSIgc3Ryb2tlLXdpZHRoPSIyIiBmaWxsPSJyZ2IoMjM3LDEwOCw5NikiLz4KICA8ZWxsaXBzZSBjeD0iMjI1IiBjeT0iNjUiIHJ4PSI1MCIgcnk9IjUyIiAgc3Ryb2tlPSJyZ2IoMjE4LDE1MSwzMykiIHN0cm9rZS13aWR0aD0iMiIgZmlsbD0icmdiKDI0NywxOTMsODEpIi8+CiAgPGVsbGlwc2UgY3g9IjM4NSIgY3k9IjY1IiByeD0iNTAiIHJ5PSI1MiIgIHN0cm9rZT0icmdiKDI3LDE2MSwzNykiIHN0cm9rZS13aWR0aD0iMiIgZmlsbD0icmdiKDEwMCwyMDAsODYpIi8+Cjwvc3ZnPg==);background-repeat:no-repeat;background-size:54px;background-position:12px center;border-bottom:1px solid color-mix(in srgb, var(--border-color), transparent 70%);border-radius:8px 8px 0 0;z-index:5}.markdown-preview-view pre:hover::before{background-color:color-mix(in srgb, var(--primary-color), transparent 95%);border-bottom-color:color-mix(in srgb, var(--primary-color), transparent 80%)}.markdown-preview-view pre code{display:block;padding:0 16px;overflow-x:auto;color:var(--code-normal) !important;font-family:var(--font-monospace);line-height:var(--code-line-height);background-color:transparent !important}.markdown-preview-view pre.language-mermaid{padding-top:0 !important;background:transparent !important;border:none !important;box-shadow:none !important}.markdown-preview-view pre.language-mermaid::before{display:none !important}.markdown-preview-view .copy-code-button{background-color:transparent;color:var(--code-comment);top:4px;right:6px;height:24px;padding:0 8px;border-radius:4px;z-index:10;transition:all 0.2s}.markdown-preview-view .copy-code-button:hover{background-color:var(--primary-color);color:#fff}.markdown-preview-view pre:not([class]){padding-top:12px !important;padding-bottom:12px !important;padding-left:16px !important;padding-right:16px !important;background-color:color-mix(in srgb, var(--primary-color), transparent 96%) !important;border:none !important;border-left:4px solid var(--primary-color) !important;border-radius:4px !important;box-shadow:none !important;margin:16px 0}.markdown-preview-view pre:not([class])::before{content:none !important;display:none !important;height:0 !important;width:0 !important}.markdown-preview-view pre:not([class]) code{color:var(--text-normal) !important;font-family:var(--font-monospace);padding:0 !important;background-color:transparent !important;display:block;white-space:pre-wrap}body.theme-dark .markdown-preview-view pre:not([class]){background-color:rgba(255, 255, 255, 0.03) !important;border-left-color:var(--primary-color) !important}.markdown-source-view.mod-cm6 .HyperMD-codeblock{font-family:var(--font-monospace) !important;line-height:1.5;border-left:1px solid var(--code-border-color, rgba(189, 147, 249, 0.3));border-right:1px solid var(--code-border-color, rgba(189, 147, 249, 0.3))}.theme-dark .markdown-source-view.mod-cm6 .HyperMD-codeblock{background-color:rgba(255, 255, 255, 0.03) !important;color:var(--text-normal)}.theme-light .markdown-source-view.mod-cm6 .HyperMD-codeblock{background-color:var(--code-background) !important;--code-border-color:color-mix(in srgb, var(--primary-color), transparent 85%);border-left:1px solid var(--code-border-color);border-right:1px solid var(--code-border-color);color:var(--code-normal) !important}.markdown-source-view.mod-cm6 .HyperMD-codeblock-begin{border-top-left-radius:8px;border-top-right-radius:8px;padding-top:6px !important;padding-bottom:6px !important;margin-top:12px;position:relative;font-weight:bold;border-top:1px solid var(--code-border-color, rgba(189, 147, 249, 0.3))}.theme-dark .markdown-source-view.mod-cm6 .HyperMD-codeblock-begin{background-color:rgba(255, 255, 255, 0.08) !important;color:var(--secondary-color) !important}.theme-light .markdown-source-view.mod-cm6 .HyperMD-codeblock-begin{background-color:var(--code-block-header-bg, #f7f7f7) !important;color:var(--primary-color) !important}.markdown-source-view.mod-cm6 .HyperMD-codeblock-end{border-bottom-left-radius:8px;border-bottom-right-radius:8px;margin-bottom:12px;border-bottom:1px solid var(--code-border-color, rgba(189, 147, 249, 0.3))}.theme-dark .markdown-source-view.mod-cm6 .HyperMD-codeblock-end{color:var(--text-muted) !important}.theme-light .markdown-source-view.mod-cm6 .HyperMD-codeblock-end{color:var(--code-comment) !important}.theme-dark .markdown-source-view.mod-cm6 .HyperMD-codeblock.cm-active{background-color:rgba(255, 255, 255, 0.05) !important}.theme-light .markdown-source-view.mod-cm6 .HyperMD-codeblock.cm-active{background-color:color-mix(in srgb, var(--primary-color), transparent 94%) !important}.cm-keyword{color:var(--code-keyword) !important}.cm-def{color:var(--code-function) !important}.cm-string{color:var(--code-string) !important}.cm-number{color:var(--code-value) !important}.cm-comment{color:var(--code-comment) !important}.cm-variable{color:var(--code-operator) !important}.cm-property{color:var(--code-property) !important}.cm-type{color:var(--code-function) !important}.cm-atom{color:var(--code-value) !important}.theme-light .cm-punctuation,.theme-light .cm-operator{color:var(--code-punctuation, #555) !important}.callout{padding:12px 16px !important;margin-block:1em !important;border:none !important;border-radius:12px !important;position:relative !important;overflow:hidden !important;mix-blend-mode:normal;transition:transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),        box-shadow 0.3s ease,        background-color 0.3s ease !important}.callout:hover{z-index:5}.callout-title{display:inline-flex !important;align-items:center;margin-bottom:12px !important;padding:4px 12px !important;border-radius:50px !important;font-weight:700;font-size:0.9em;line-height:1.2;color:inherit !important;background-color:rgba(255, 255, 255, 0.6) !important;border:1px solid rgba(0, 0, 0, 0.05) !important;position:relative;z-index:2}.callout-icon{display:inline-flex !important;align-items:center;justify-content:center;margin-right:6px !important;flex:0 0 auto !important;color:currentColor !important}.callout-icon svg{width:16px !important;height:16px !important;display:block !important;opacity:1 !important;fill:currentColor !important;stroke:currentColor !important;stroke-width:2px}.callout::after{content:"✨";position:absolute !important;right:-10px !important;bottom:-15px !important;font-family:"Segoe UI Emoji", "Apple Color Emoji", sans-serif;font-size:80px !important;line-height:1;opacity:0.12 !important;transform:rotate(-15deg);filter:grayscale(100%);pointer-events:none;z-index:0;transition:all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) !important}.callout:hover::after{transform:rotate(0deg) scale(1.1) !important;opacity:0.25 !important;right:0px !important;bottom:-5px !important;filter:grayscale(0%) !important}.callout-content{position:relative;z-index:2}.callout-content ul.contains-task-list{margin-left:2px}.markdown-source-view.mod-cm6 .callout-content ul.contains-task-list input.task-list-item-checkbox{transform:translateY(4px)}.theme-light .callout[data-callout="note"],.theme-light .callout[data-callout="info"],.theme-light .callout[data-callout="todo"]{background-color:rgba(48, 107, 214, 0.1) !important}.theme-light .callout[data-callout="note"] .callout-title{color:#6c5ce7 !important}.theme-light .callout[data-callout="note"]:hover{background-color:rgba(108, 92, 231, 0.15) !important}.theme-light .callout[data-callout="note"]::after{content:"📝";color:#6c5ce7}.theme-light .callout[data-callout="info"]::after{content:"ℹ️";color:#6c5ce7}.theme-light .callout[data-callout="todo"]::after{content:"✅";color:#6c5ce7}.theme-light .callout[data-callout="tip"]{background-color:rgba(0, 184, 148, 0.1) !important}.theme-light .callout[data-callout="tip"] .callout-title{color:#00b894 !important}.theme-light .callout[data-callout="tip"]:hover{background-color:rgba(0, 184, 148, 0.15) !important}.theme-light .callout[data-callout="tip"]::after{content:"💡";color:#00b894}.theme-light .callout[data-callout="warning"]{background-color:rgba(253, 203, 110, 0.15) !important}.theme-light .callout[data-callout="warning"] .callout-title{color:#e17055 !important}.theme-light .callout[data-callout="warning"]:hover{background-color:rgba(253, 203, 110, 0.2) !important}.theme-light .callout[data-callout="warning"]::after{content:"⚠️";color:#e17055}.theme-light .callout[data-callout="important"]{background-color:rgba(255, 118, 117, 0.12) !important}.theme-light .callout[data-callout="important"] .callout-title{color:#ff7675 !important}.theme-light .callout[data-callout="important"]:hover{background-color:rgba(255, 118, 117, 0.18) !important}.theme-light .callout[data-callout="important"]::after{content:"📌";color:#ff7675}.theme-light .callout[data-callout="caution"],.theme-light .callout[data-callout="bug"]{background-color:rgba(214, 48, 49, 0.08) !important}.theme-light .callout[data-callout="caution"] .callout-title{color:#d63031 !important}.theme-light .callout[data-callout="caution"]:hover{background-color:rgba(214, 48, 49, 0.12) !important}.theme-light .callout[data-callout="caution"]::after{content:"🔥";color:#d63031}.theme-light .callout[data-callout="success"],.theme-light .callout[data-callout="done"]{background-color:rgba(85, 239, 196, 0.15) !important}.theme-light .callout[data-callout="success"] .callout-title{color:#00b894 !important}.theme-light .callout[data-callout="success"]:hover{background-color:rgba(85, 239, 196, 0.25) !important}.theme-light .callout[data-callout="success"]::after{content:"🎉";color:#00b894}.theme-light .callout[data-callout="example"]{background-color:rgba(162, 155, 254, 0.15) !important}.theme-light .callout[data-callout="example"] .callout-title{color:#6c5ce7 !important}.theme-light .callout[data-callout="example"]:hover{background-color:rgba(162, 155, 254, 0.25) !important}.theme-light .callout[data-callout="example"]::after{content:"🧩";color:#6c5ce7}.theme-light .callout[data-callout="quote"]{background-color:rgba(178, 190, 195, 0.15) !important}.theme-light .callout[data-callout="quote"] .callout-title{color:#636e72 !important}.theme-light .callout[data-callout="quote"]:hover{background-color:rgba(178, 190, 195, 0.25) !important}.theme-light .callout[data-callout="quote"]::after{content:"💬";color:#636e72}.theme-light .callout[data-callout="danger"],.theme-light .callout[data-callout="error"]{background-color:rgba(214, 48, 49, 0.15) !important;border-left-color:#d63031 !important}.theme-light .callout[data-callout="danger"] .callout-title,.theme-light .callout[data-callout="error"] .callout-title{color:#d63031 !important}.theme-light .callout[data-callout="danger"]:hover,.theme-light .callout[data-callout="error"]:hover{background-color:rgba(214, 48, 49, 0.2) !important}.theme-light .callout[data-callout="danger"]::after{content:"⚡";color:#d63031}.theme-light .callout[data-callout="error"]::after{content:"❌";color:#d63031}.theme-light .callout[data-callout="bug"]::after{content:"🐛";color:#d63031}.theme-light .callout[data-callout="failure"],.theme-light .callout[data-callout="missing"]{background-color:rgba(45, 52, 54, 0.05) !important}.theme-light .callout[data-callout="failure"] .callout-title{color:#c0392b !important}.theme-light .callout[data-callout="failure"]:hover{background-color:rgba(45, 52, 54, 0.1) !important}.theme-light .callout[data-callout="failure"]::after{content:"📉";color:#c0392b}.theme-light .callout[data-callout="question"],.theme-light .callout[data-callout="faq"],.theme-light .callout[data-callout="help"]{background-color:rgba(253, 203, 110, 0.15) !important}.theme-light .callout[data-callout="question"] .callout-title{color:#f39c12 !important}.theme-light .callout[data-callout="question"]:hover{background-color:rgba(253, 203, 110, 0.25) !important}.theme-light .callout[data-callout="question"]::after{content:"❓";color:#f39c12}.theme-light .callout[data-callout="abstract"],.theme-light .callout[data-callout="summary"],.theme-light .callout[data-callout="tldr"]{background-color:rgba(129, 236, 236, 0.2) !important}.theme-light .callout[data-callout="abstract"] .callout-title{color:#00cec9 !important}.theme-light .callout[data-callout="abstract"]:hover{background-color:rgba(129, 236, 236, 0.3) !important}.theme-light .callout[data-callout="abstract"]::after{content:"📑";color:#00cec9}.theme-dark .callout{background-color:rgba(255, 255, 255, 0.03) !important;border:1px solid rgba(255, 255, 255, 0.05) !important}.theme-dark .callout-title{background-color:rgba(255, 255, 255, 0.08) !important;border:1px solid rgba(255, 255, 255, 0.1) !important;color:var(--text-normal) !important}.theme-dark .callout[data-callout="note"]{border-color:rgba(189, 147, 249, 0.3) !important;background-color:rgba(189, 147, 249, 0.1) !important}.theme-dark .callout[data-callout="note"] .callout-title{color:#bd93f9 !important}.theme-dark .callout[data-callout="note"]:hover{background-color:rgba(189, 147, 249, 0.2) !important}.theme-dark .callout[data-callout="note"]::after{content:"📝";color:#bd93f9}.theme-dark .callout[data-callout="tip"]{border-color:rgba(139, 233, 253, 0.3) !important;background-color:rgba(139, 233, 253, 0.1) !important}.theme-dark .callout[data-callout="tip"] .callout-title{color:#8be9fd !important}.theme-dark .callout[data-callout="tip"]:hover{background-color:rgba(139, 233, 253, 0.2) !important}.theme-dark .callout[data-callout="tip"]::after{content:"💡";color:#8be9fd}.theme-dark .callout[data-callout="warning"]{border-color:rgba(255, 184, 108, 0.3) !important;background-color:rgba(255, 184, 108, 0.1) !important}.theme-dark .callout[data-callout="warning"] .callout-title{color:#ffb86c !important}.theme-dark .callout[data-callout="warning"]:hover{background-color:rgba(255, 184, 108, 0.2) !important}.theme-dark .callout[data-callout="warning"]::after{content:"⚠️";color:#ffb86c}.theme-dark .callout[data-callout="important"]{border-color:rgba(255, 85, 85, 0.3) !important;background-color:rgba(255, 85, 85, 0.1) !important}.theme-dark .callout[data-callout="important"] .callout-title{color:#ff5555 !important}.theme-dark .callout[data-callout="important"]:hover{background-color:rgba(255, 85, 85, 0.2) !important}.theme-dark .callout[data-callout="important"]::after{content:"🔥";color:#ff5555}.theme-dark .callout[data-callout="info"]{border-color:rgba(116, 192, 252, 0.3) !important;background-color:rgba(116, 192, 252, 0.1) !important}.theme-dark .callout[data-callout="info"] .callout-title{color:#74c0fc !important}.theme-dark .callout[data-callout="info"]::after{content:"ℹ️";color:#74c0fc}.theme-dark .callout[data-callout="todo"]{border-color:rgba(80, 250, 123, 0.3) !important;background-color:rgba(80, 250, 123, 0.1) !important}.theme-dark .callout[data-callout="todo"] .callout-title{color:#50fa7b !important}.theme-dark .callout[data-callout="todo"]::after{content:"✅";color:#50fa7b}.theme-dark .callout[data-callout="success"],.theme-dark .callout[data-callout="done"]{border-color:rgba(85, 239, 196, 0.3) !important;background-color:rgba(85, 239, 196, 0.1) !important}.theme-dark .callout[data-callout="success"] .callout-title{color:#55efc4 !important}.theme-dark .callout[data-callout="success"]:hover{background-color:rgba(85, 239, 196, 0.15) !important}.theme-dark .callout[data-callout="success"]::after{content:"🎉";color:#55efc4}.theme-dark .callout[data-callout="question"],.theme-dark .callout[data-callout="faq"],.theme-dark .callout[data-callout="help"]{border-color:rgba(241, 250, 140, 0.3) !important;background-color:rgba(241, 250, 140, 0.1) !important}.theme-dark .callout[data-callout="question"] .callout-title{color:#f1fa8c !important}.theme-dark .callout[data-callout="question"]:hover{background-color:rgba(241, 250, 140, 0.15) !important}.theme-dark .callout[data-callout="question"]::after{content:"❓";color:#f1fa8c}.theme-dark .callout[data-callout="example"]{border-color:rgba(255, 121, 198, 0.3) !important;background-color:rgba(255, 121, 198, 0.1) !important}.theme-dark .callout[data-callout="example"] .callout-title{color:#ff79c6 !important}.theme-dark .callout[data-callout="example"]:hover{background-color:rgba(255, 121, 198, 0.15) !important}.theme-dark .callout[data-callout="example"]::after{content:"🧩";color:#ff79c6}.theme-dark .callout[data-callout="quote"]{border-color:rgba(223, 230, 233, 0.2) !important;background-color:rgba(223, 230, 233, 0.05) !important}.theme-dark .callout[data-callout="quote"] .callout-title{color:#dfe6e9 !important}.theme-dark .callout[data-callout="quote"]::after{content:"💬";color:#dfe6e9}.theme-dark .callout[data-callout="danger"],.theme-dark .callout[data-callout="error"]{border-color:rgba(255, 85, 85, 0.4) !important;background-color:rgba(255, 85, 85, 0.1) !important;box-shadow:0 0 10px rgba(255, 85, 85, 0.1)}.theme-dark .callout[data-callout="danger"] .callout-title,.theme-dark .callout[data-callout="error"] .callout-title{color:#ff5555 !important}.theme-dark .callout[data-callout="danger"]::after{content:"⚡";color:#ff5555}.theme-dark .callout[data-callout="error"]::after{content:"❌";color:#ff5555}*/ .theme-dark .callout[data-callout="bug"]{border-color:rgba(255, 85, 85, 0.4) !important;background-color:rgba(255, 85, 85, 0.1) !important}.theme-dark .callout[data-callout="bug"] .callout-title{color:#ff5555 !important}.theme-dark .callout[data-callout="bug"]::after{content:"🐛";color:#ff5555}.theme-dark .callout[data-callout="failure"],.theme-dark .callout[data-callout="missing"]{border-color:rgba(179, 57, 57, 0.3) !important;background-color:rgba(0, 0, 0, 0.2) !important}.theme-dark .callout[data-callout="failure"] .callout-title{color:#fab1a0 !important}.theme-dark .callout[data-callout="failure"]::after{content:"📉";color:#fab1a0}.theme-dark .callout[data-callout="abstract"],.theme-dark .callout[data-callout="summary"]{border-color:rgba(129, 236, 236, 0.3) !important;background-color:rgba(129, 236, 236, 0.1) !important}.theme-dark .callout[data-callout="abstract"] .callout-title{color:#81ecec !important}.theme-dark .callout[data-callout="abstract"]::after{content:"📑";color:#81ecec}.markdown-source-view.mod-cm6 .cm-embed-block:not(.cm-table-widget, .cm-lang-base):hover{box-shadow:none}.markdown-preview-view :not(pre)>code,.markdown-source-view.mod-cm6 .cm-inline-code:not(.cm-formatting){font-family:var(--font-monospace) !important;letter-spacing:0.5px;background-color:color-mix(in srgb, var(--primary-color), transparent 90%);color:var(--primary-color) !important;border:1px solid color-mix(in srgb, var(--primary-color), transparent 85%);padding:2px 6px !important;margin:0 2px;border-radius:6px;vertical-align:middle;transition:all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);-webkit-box-decoration-break:clone;box-decoration-break:clone}.markdown-preview-view :not(pre)>code:hover{background-color:var(--primary-color) !important;color:#fff !important;border-color:var(--primary-color);box-shadow:0 0 15px color-mix(in srgb, var(--primary-color), transparent 60%);transform:scale(1.05);text-decoration:none !important;-webkit-text-fill-color:#fff !important;position:relative;z-index:1}.markdown-source-view.mod-cm6 .cm-formatting-code{color:var(--primary-color) !important;opacity:0.4;font-family:var(--font-monospace);font-weight:bold}.markdown-preview-view kbd,.markdown-source-view.mod-cm6 .cm-kbd,.markdown-source-view.mod-cm6 kbd{font-family:var(--font-monospace), "CascadiaCode", Consolas, monospace;font-size:0.9em;font-weight:600;line-height:1;text-align:center;display:inline-block;min-width:1.6em;padding:3px 6px;margin:0 4px;border-radius:6px;vertical-align:middle;transition:all 0.15s cubic-bezier(0.25, 0.8, 0.25, 1);text-shadow:none;cursor:default}body.theme-dark .markdown-preview-view kbd,body.theme-dark .markdown-source-view.mod-cm6 .cm-kbd,body.theme-dark .markdown-source-view.mod-cm6 kbd{background-color:#333;color:var(--text-color);border:1px solid #444;border-top-color:#555;border-bottom-color:#222;box-shadow:0 4px 0 #222, 0 5px 5px rgba(0, 0, 0, 0.4)}body.theme-dark .markdown-preview-view kbd:hover,body.theme-dark .markdown-source-view.mod-cm6 .cm-kbd:hover,body.theme-dark .markdown-source-view.mod-cm6 kbd:hover{transform:translateY(2px);box-shadow:0 2px 0 #222, 0 3px 3px rgba(0, 0, 0, 0.4);color:var(--primary-color);border-color:var(--primary-color)}body.theme-light .markdown-preview-view kbd,body.theme-light .markdown-source-view.mod-cm6 .cm-kbd,body.theme-light .markdown-source-view.mod-cm6 kbd{background-color:#fff;color:var(--primary-color);border:1px solid var(--primary-color);border-bottom-width:3px;box-shadow:0 2px 4px color-mix(in srgb, var(--primary-color), transparent 85%)}body.theme-light .markdown-preview-view kbd:hover,body.theme-light .markdown-source-view.mod-cm6 .cm-kbd:hover,body.theme-light .markdown-source-view.mod-cm6 kbd:hover{transform:translateY(2px);border-bottom-width:1px;background-color:color-mix(in srgb, var(--primary-color), transparent 90%);box-shadow:none}.mermaid{display:block !important;width:100% !important;overflow-x:auto !important;overflow-y:hidden;margin:1em 0;padding-bottom:8px;text-align:center;background-color:transparent !important}.mermaid .node rect,.mermaid .node circle,.mermaid .node ellipse,.mermaid .node path{fill:color-mix(in srgb, var(--primary-color), transparent 90%) !important;stroke:var(--primary-color) !important;stroke-width:1.5px !important;opacity:1 !important}.mermaid .node polygon{fill:color-mix(in srgb, var(--secondary-color), transparent 85%) !important;stroke:var(--secondary-color) !important;stroke-width:1.5px !important}.mermaid .label,.mermaid foreignObject,.mermaid foreignObject div,.mermaid foreignObject span,.mermaid foreignObject p,.mermaid span.nodeLabel{color:var(--mermaid-text-color) !important;fill:#ffffff !important;background-color:transparent !important;background:none !important;border:none !important;box-shadow:none !important;font-size:12px !important;line-height:1.5 !important;font-weight:500 !important}.mermaid foreignObject{overflow:visible !important}.mermaid .node .label,.mermaid .label{stroke:none !important}.mermaid .edgePath .path,.mermaid .flowchart-link{stroke:#999 !important;stroke-width:1.5px !important;opacity:1 !important}.mermaid .marker path,.mermaid marker path{fill:#e0e0e0 !important;stroke:#e0e0e0 !important}.mermaid .edgeLabel .label rect{fill:#2e2e2e !important;opacity:1 !important;rx:4px}.mermaid .edgeLabel .label{background-color:#2e2e2e !important}.mermaid::-webkit-scrollbar{height:6px}.mermaid::-webkit-scrollbar-track{background:rgba(255, 255, 255, 0.05);border-radius:3px}.mermaid::-webkit-scrollbar-thumb{background:var(--primary-color);border-radius:3px}.mermaid::-webkit-scrollbar-thumb:hover{background:var(--secondary-color)}.community-modal-info{--h2-color:var(--primary-color)}.nav-file-tag{line-height:1rem}.modal{background-color:var(--background-primary);border-radius:16px;border:1px solid var(--border-color);box-shadow:0 20px 60px -10px rgba(0, 0, 0, 0.4);overflow:auto;max-width:1100px;transition:transform 0.2s ease, opacity 0.2s ease}.theme-dark .modal{background-color:rgba(20, 20, 25, 0.85);backdrop-filter:blur(20px) saturate(180%);-webkit-backdrop-filter:blur(20px) saturate(180%);border:1px solid rgba(255, 255, 255, 0.08);box-shadow:0 0 0 1px rgba(0, 0, 0, 0.2), 0 30px 80px -10px rgba(0, 0, 0, 0.6)}.theme-light .modal{background-color:rgba(255, 255, 255, 0.85);backdrop-filter:blur(20px) saturate(120%);-webkit-backdrop-filter:blur(20px) saturate(120%);border:1px solid rgba(0, 0, 0, 0.05);box-shadow:0 10px 40px -5px rgba(0, 0, 0, 0.1)}.modal-close-button{position:absolute;top:16px;right:16px;z-index:10;opacity:0.6;transition:all 0.2s ease}.modal-close-button:hover{opacity:1;background-color:var(--background-modifier-hover);color:var(--text-error);transform:rotate(90deg)}.vertical-tab-header{background-color:color-mix(in srgb, var(--background-secondary), transparent 60%);border-right:1px solid var(--border-color);width:230px;padding:15px 8px;flex-shrink:0}.vertical-tab-header-group-title{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.05em;color:var(--text-muted);margin:2px 0 4px 10px}.vertical-tab-nav-item{display:flex;align-items:center;padding:5px 10px;margin-bottom:2px;border-radius:6px;cursor:pointer;font-size:14px;color:var(--text-normal);transition:all 0.2s ease;position:relative}.vertical-tab-nav-item-icon{margin-right:8px;color:var(--text-muted);display:flex;align-items:center;transition:color 0.2s ease}.vertical-tab-nav-item-icon svg{width:16px;height:16px;stroke-width:2px}.vertical-tab-nav-item:hover{background-color:var(--background-modifier-hover);color:var(--text-normal)}.vertical-tab-nav-item:hover .vertical-tab-nav-item-icon{color:var(--text-normal)}.vertical-tab-nav-item.is-active{background-color:var(--primary-color) !important;color:#ffffff !important;font-weight:600;box-shadow:0 2px 8px color-mix(in srgb, var(--primary-color), transparent 50%)}.vertical-tab-nav-item.is-active .vertical-tab-nav-item-icon{color:#ffffff !important;opacity:1}.workspace-leaf-content[data-type="bases"]{--bases-table-row-border-width:0px !important;--bases-table-column-border-width:0px !important;--table-border-width:0px !important;--bases-table-row-height:40px !important;--bases-table-font-size:14px !important;--bases-table-header-background:var(--background-primary);--bases-table-group-background:var(--background-primary)}.bases-toolbar{border-bottom:1px solid var(--border-color);padding:8px 16px;gap:12px}.bases-toolbar .text-icon-button{background-color:transparent;border:1px solid transparent;border-radius:8px;padding:4px 12px;color:var(--text-muted);font-size:13px;transition:all 0.2s ease;box-shadow:none !important}.bases-toolbar .text-icon-button:hover,.bases-toolbar .text-icon-button.is-active{background-color:var(--background-modifier-hover);color:var(--text-normal)}.bases-toolbar .text-button-icon svg{width:16px;height:16px;opacity:0.8}.bases-thead{background-color:var(--background-primary) !important;border-bottom:2px solid var(--background-modifier-border);box-shadow:none !important;z-index:10}.bases-table-header{color:var(--text-muted);font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;padding-left:12px}.bases-tr{box-shadow:none !important;border-bottom:1px solid transparent;transition:all 0.2s cubic-bezier(0.25, 0.8, 0.25, 1);cursor:pointer;margin:0 4px;width:calc(100% - 8px) !important;border-radius:8px}.bases-tr:hover{background-color:color-mix(in srgb, var(--primary-color), transparent 88%) !important;box-shadow:0 2px 8px rgba(0, 0, 0, 0.05),        inset 0 0 0 1px color-mix(in srgb, var(--primary-color), transparent 90%) !important;border-bottom-color:transparent;transform:scale(1.005);z-index:10}.bases-tr:hover .bases-rendered-value{color:var(--text-normal) !important}.bases-tr:hover .internal-link{color:var(--primary-color) !important;text-decoration:none !important}.bases-tr.is-selected{background-color:color-mix(in srgb, var(--primary-color), transparent 80%) !important;box-shadow:inset 3px 0 0 var(--primary-color)}.bases-tr:hover .bases-td:first-child{border-top-left-radius:8px;border-bottom-left-radius:8px}.bases-tr:hover .bases-td:last-child{border-top-right-radius:8px;border-bottom-right-radius:8px}.bases-td{box-shadow:none !important;padding:0 12px !important;border-right:none !important}.bases-rendered-value{padding:0 !important;display:flex;align-items:center}.bases-rendered-value .internal-link{text-decoration:none !important;color:var(--text-normal) !important;font-weight:400;transition:color 0.2s ease}.bases-rendered-value .internal-link:hover{color:var(--primary-color) !important;text-decoration:underline !important;text-underline-offset:4px}.bases-table-header-icon{display:none}.bases-view{background-color:var(--background-primary)}.theme-light .bases-tr:not(:hover){border-bottom:1px solid rgba(0, 0, 0, 0.03)}.theme-dark .bases-tr:not(:hover){border-bottom:1px solid rgba(255, 255, 255, 0.03)}body{--scrollbar-bg:transparent;--scrollbar-thumb-bg:rgba(var(--mono-rgb-100), 0.1);--scrollbar-active-thumb-bg:rgba(var(--mono-rgb-100), 0.2)}body.theme-dark{--scrollbar-thumb-bg:rgba(255, 255, 255, 0.1);--scrollbar-active-thumb-bg:rgba(255, 255, 255, 0.2)}body.theme-light{--scrollbar-thumb-bg:rgba(0, 0, 0, 0.1);--scrollbar-active-thumb-bg:rgba(0, 0, 0, 0.2)}body:not(.restored-scrollbars) ::-webkit-scrollbar,body:not(.restored-scrollbars) .kanban-plugin__scroll-container::-webkit-scrollbar{width:8px;height:8px;background-color:var(--scrollbar-bg)}body:not(.restored-scrollbars) ::-webkit-scrollbar-thumb,body:not(.restored-scrollbars) .kanban-plugin__scroll-container::-webkit-scrollbar-thumb{background-clip:padding-box;border-radius:20px;border:2px solid transparent;min-height:45px;background-color:transparent}body:not(.restored-scrollbars) .mobile-toolbar-options-container::-webkit-scrollbar{display:none}body:not(.restored-scrollbars):not(.is-mobile) :hover::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb-bg) !important}body:not(.restored-scrollbars) ::-webkit-scrollbar-thumb:hover,body:not(.restored-scrollbars) ::-webkit-scrollbar-thumb:active{background-color:var(--scrollbar-active-thumb-bg) !important}.workspace-leaf-content:is([data-type="surfing-view"], [data-type="graph"], [data-type="localgraph"]) ::-webkit-scrollbar,.scrollbar-hide ::-webkit-scrollbar{display:none}body.layout-cards:not(.is-mobile) .workspace-tabs:not(.mod-stacked) .workspace-leaf,body.layout-cards:not(.is-mobile) .workspace-tabs:not(.mod-stacked) .workspace-leaf-content,body.layout-cards:not(.is-mobile) .workspace-tabs:not(.mod-stacked) .view-header:not(.animate),body.layout-cards:not(.is-mobile) .workspace-tabs:not(.mod-stacked) .view-content:not(.vignette-radial, .vignette-linear, .animate, .ptm-fullscreen-writing-focus-element),body.layout-cards .mod-left-split .workspace-tab-header.has-active-menu,body.layout-cards .mod-right-split .workspace-tab-header.has-active-menu,body.layout-cards:not(.is-mobile) .workspace-tab-header-container,body.layout-cards .workspace>.workspace-split{background-color:transparent !important}body.layout-cards .workspace-tab-header-container,body.layout-cards .workspace-tabs.mod-top .workspace-tab-header-container,body.layout-cards .workspace-ribbon.mod-left:before{border-bottom:1px solid var(--background-card) !important}body.layout-cards .workspace-ribbon{border-right:transparent !important;background-color:var(--background-card)}body.layout-cards .sidebar-toggle-button,body.layout-cards .workspace-tabs.mod-top{background-color:var(--background-card)}body.layout-cards .workspace-ribbon.mod-left:before{background:transparent !important}body.layout-cards .workspace-leaf-resize-handle{--workspace-divider-color:transparent;border-color:var(--workspace-divider-color)}body.layout-cards .is-hidden-frameless:not(.is-fullscreen).is-focused .titlebar-button-container.mod-right{background-color:transparent}body.layout-cards:not(.is-mobile).mod-left-split .workspace-sidedock-vault-profile{border:0;padding:0;z-index:99}body.layout-cards .workspace-sidedock-vault-profile{border-top:transparent !important}body.layout-cards:not(.is-mobile) .workspace-split.mod-left-split .workspace-sidedock-vault-profile{background-color:var(--background-card)}body.layout-cards:not(.is-mobile).theme-light .workspace-tab-container{border-radius:20px 20px 10px 10px;border:1px solid color-mix(in srgb, var(--primary-color), transparent 80%);margin:8px 10px;background-color:color-mix(in srgb, var(--primary-color), #fff 96%)}body.layout-cards.theme-light .mod-vertical .workspace-tab-header-container{padding-left:20px}body.layout-cards.theme-light .mod-vertical:not(.mod-left-split):not(.mod-right-split) .workspace-tabs:not(.mod-stacked) .workspace-tab-header-container-inner{align-items:center;justify-content:center;margin:0;margin-top:3px;width:100%;gap:10px;z-index:1}body.layout-cards.theme-light .mod-vertical:not(.mod-left-split):not(.mod-right-split) .workspace-tabs:not(.mod-stacked) .workspace-tab-header{background:color-mix(in srgb, var(--primary-color), #fff 96%);border-radius:6px;border:1px solid rgba(255, 255, 255, 0.1);box-shadow:0 0 8px rgba(0, 0, 0, 0.15), inset 0 1px 1px rgba(255, 255, 255, 0.15);height:32px;padding:0 !important;transition:400ms, background-color 150ms ease-in-out}body.layout-cards.theme-light .mod-vertical:not(.mod-left-split):not(.mod-right-split) .workspace-tabs:not(.mod-stacked) .workspace-tab-header.is-active{border:1px solid color-mix(in srgb, var(--primary-color), #fff 70%);box-shadow:0 0 8px color-mix(in srgb, var(--primary-color), transparent 75%), inset 0 1px 1px color-mix(in srgb, var(--primary-color), transparent 75%);background-color:var(--background-primary);font-weight:bold;flex-grow:1.67;max-width:240px}body.layout-cards.theme-light .mod-root:not(.mod-left-split):not(.mod-right-split) .workspace-tabs:not(.mod-stacked) .workspace-tab-header-inner{padding:0 4px 0 8px;transition:400ms, background-color 150ms ease-in-out, max-width 400ms}body.layout-cards .workspace-tab-header-container .workspace-tab-header::before,body.layout-cards .workspace-tab-header-container .workspace-tab-header::after,body.layout-cards .workspace .mod-root .workspace-tab-header-inner::after{display:none}body.layout-cards:not(.is-phone).theme-light .modal-container.mod-dim .modal,body.layout-cards:not(.is-phone).theme-light .status-bar{border-radius:var(--radius-xl);background:rgba(255, 255, 255, 0.6);border:1px solid rgba(255, 255, 255, 0.4);box-shadow:0 0 8px rgba(0, 0, 0, 0.05), inset 0 1px 1px rgba(255, 255, 255, 0.5);margin:0 5px 5px 5px;transform:translate(0, -5px)}body.layout-cards:not(.is-phone).theme-light .workspace-tabs{background:var(--background-card)}body.layout-cards:not(.is-mobile).theme-dark .workspace-tab-container{border-radius:20px 20px 10px 10px;border:1px solid rgba(255, 255, 255, 0.08);margin:8px 10px;background-color:var(--background-primary);box-shadow:0 2px 6px rgba(0, 0, 0, 0.4)}body.layout-cards.theme-dark .mod-vertical:not(.mod-left-split):not(.mod-right-split) .workspace-tabs:not(.mod-stacked) .workspace-tab-header{background:rgba(255, 255, 255, 0.03);border-radius:6px;border:1px solid rgba(255, 255, 255, 0.05);box-shadow:none;height:32px;padding:0 !important;transition:400ms, background-color 150ms ease-in}body.layout-cards.theme-dark .mod-vertical:not(.mod-left-split):not(.mod-right-split) .workspace-tabs:not(.mod-stacked) .workspace-tab-header.is-active{border:1px solid rgba(255, 255, 255, 0.1);box-shadow:0 2px 10px rgba(0, 0, 0, 0.3);background-color:var(--background-secondary);font-weight:bold;flex-grow:1.67;max-width:240px}body.layout-cards.theme-dark .workspace-tab-header.is-active .workspace-tab-header-inner-title{color:var(--text-normal)}body.layout-cards.theme-dark .mod-vertical:not(.mod-left-split):not(.mod-right-split) .workspace-tabs:not(.mod-stacked) .workspace-tab-header-container-inner{align-items:center;justify-content:center;margin:0;margin-top:3px;width:100%;gap:10px}body.layout-cards:not(.is-phone).theme-dark .modal-container.mod-dim .modal,body.layout-cards:not(.is-phone).theme-dark .status-bar{border-radius:var(--radius-xl);background:rgba(30, 30, 30, 0.6);border:1px solid rgba(255, 255, 255, 0.08);box-shadow:0 0 20px rgba(0, 0, 0, 0.5);margin:0 5px 5px 5px;transform:translate(0, -5px)}.community-modal-meta{display:grid;grid-template-areas:"name name name name"        "desc desc desc desc"        "stats stats stats stats"        "buttons buttons buttons buttons";grid-template-columns:2fr 2fr 2fr 1fr;gap:16px;margin-bottom:0 !important}.community-modal-info-name{grid-area:name;font-size:24px;font-weight:800;color:var(--primary-color);line-height:1.2;margin-bottom:4px;display:flex;align-items:center;gap:10px;flex-wrap:wrap}.flair{font-size:11px;background-color:var(--background-secondary) !important;border:1px solid var(--border-color);color:var(--text-muted) !important;padding:2px 8px;border-radius:50px;text-transform:uppercase;font-weight:bold;letter-spacing:0.5px;top:-2px;position:relative}.flair.mod-pop{color:var(--secondary-color) !important;border-color:var(--secondary-color);background-color:color-mix(in srgb, var(--secondary-color), transparent 90%) !important}.community-modal-info-desc{grid-area:desc;font-size:15px;line-height:1.6;color:var(--text-normal);opacity:0.9;padding-bottom:20px;border-bottom:1px dashed var(--border-color);margin-bottom:8px}.community-modal-info-downloads,.community-modal-info-version,.community-modal-info-author,.community-modal-info-repo{display:flex;flex-direction:column;justify-content:center;gap:4px;padding:12px;background-color:var(--background-secondary);border-radius:8px;font-size:13px;color:var(--text-muted);margin:0 !important;min-width:0}.community-modal-info-downloads{grid-area:stats;grid-column:1}.community-modal-info-version{grid-area:stats;grid-column:2}.community-modal-info-author{grid-area:stats;grid-column:3}.community-modal-info-repo{grid-area:stats;grid-column:4}@media (max-width:700px){.community-modal-meta{grid-template-areas:"name"            "desc"            "stats-1"            "stats-2"            "stats-3"            "stats-4"            "buttons";grid-template-columns:1fr}.community-modal-info-downloads{grid-area:stats-1;grid-column:auto}.community-modal-info-version{grid-area:stats-2;grid-column:auto}.community-modal-info-author{grid-area:stats-3;grid-column:auto}.community-modal-info-repo{grid-area:stats-4;grid-column:auto}}.community-modal-info-downloads{color:var(--text-normal);font-weight:bold;border:1px solid color-mix(in srgb, var(--primary-color), transparent 80%);background-color:color-mix(in srgb, var(--primary-color), transparent 96%)}.community-modal-info-downloads::before{content:"DOWNLOADS";font-size:10px;font-weight:bold;color:var(--primary-color);opacity:0.7;margin-bottom:4px;letter-spacing:0.5px}.community-modal-info-downloads span{display:flex;align-items:center;gap:6px;font-size:16px}.community-modal-info-downloads svg{width:16px;height:16px;color:var(--primary-color)}.community-modal-info-version::before{content:"VERSION"}.community-modal-info-author::before{content:"AUTHOR"}.community-modal-info-repo::before{content:"REPOSITORY"}.community-modal-info-version::before,.community-modal-info-author::before,.community-modal-info-repo::before{font-size:10px;font-weight:bold;color:var(--text-muted);opacity:0.6;margin-bottom:2px;display:block}.community-modal-info-author a,.community-modal-info-repo a{color:var(--text-normal);text-decoration:none;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block}.community-modal-info-author a:hover,.community-modal-info-repo a:hover{color:var(--primary-color);text-decoration:underline}.community-modal-button-container{grid-area:buttons;margin-top:20px;padding-top:20px;border-top:1px dashed var(--border-color);display:flex;gap:10px;flex-wrap:wrap}.community-modal-button-container button{flex:1;justify-content:center}.codeblock-customizer-line-number,.codeblock-customizer-line-number-specific{background:transparent}body.rainbow-folders .nav-folder{--nav-c-pink:#ff7096;--nav-c-cyan:#3db8bf;--nav-c-orange:#f59e0b;--nav-c-green:#11aa63;--nav-c-purple:#A06EB4;--nav-c-red:#aa1141;--nav-c-blue:#1D4E89;--folder-color:var(--text-muted);--nav-item-background-hover:color-mix(in srgb, var(--folder-color), transparent 95%);--background-modifier-active-hover:color-mix(in srgb, var(--primary-color), transparent 95%)}body.rainbow-folders .nav-files-container{--folder-color:var(--primary-color);--nav-item-background-hover:color-mix(in srgb, var(--primary-color), transparent 95%);--background-modifier-active-hover:color-mix(in srgb, var(--primary-color), transparent 90%)}body.rainbow-folders .nav-files-container > div > .nav-folder:nth-child(7n+1){--folder-color:var(--nav-c-pink)}body.rainbow-folders .nav-files-container > div > .nav-folder:nth-child(7n+2){--folder-color:var(--nav-c-cyan)}body.rainbow-folders .nav-files-container > div > .nav-folder:nth-child(7n+3){--folder-color:var(--nav-c-orange)}body.rainbow-folders .nav-files-container > div > .nav-folder:nth-child(7n+4){--folder-color:var(--nav-c-green)}body.rainbow-folders .nav-files-container > div > .nav-folder:nth-child(7n+5){--folder-color:var(--nav-c-purple)}body.rainbow-folders .nav-files-container > div > .nav-folder:nth-child(7n+6){--folder-color:var(--nav-c-red)}body.rainbow-folders .nav-files-container > div > .nav-folder:nth-child(7n+7){--folder-color:var(--nav-c-blue)}body.rainbow-folders .nav-files-container > div > .nav-folder{margin:0 0 8px 0 !important;padding:0px 0 !important;border-radius:0 8px 8px 0;border-left:4px solid var(--folder-color) !important;transition:background-color 0.2s ease}body.rainbow-folders .nav-folder .nav-folder{border-left:none !important;background-color:transparent !important;margin:0 !important;padding:0 !important;border-radius:0}body.rainbow-folders .nav-folder.is-collapsed{padding-bottom:0 !important}body.rainbow-folders .nav-folder-title{padding:6px 8px !important;margin:1px 0 !important;border-radius:6px;font-weight:500;color:var(--folder-color);display:flex;align-items:center}body.rainbow-folders .nav-folder .nav-folder .nav-folder-title-content{opacity:0.9}body.rainbow-folders .nav-folder-title:hover{background-color:var(--background-modifier-hover)}body.rainbow-folders .nav-folder-collapse-indicator,body.rainbow-folders .nav-folder .collapse-icon{display:none !important}body.rainbow-folders .nav-folder-children{margin-left:14px !important;padding-left:10px !important;border-left:1px solid color-mix(in srgb, var(--folder-color), transparent 70%)}body.rainbow-folders .nav-folder:hover > .nav-folder-children{border-left-color:color-mix(in srgb, var(--folder-color), transparent 40%)}body.rainbow-folders .nav-folder-title-content::before,body.rainbow-folders .nav-file-title-content::before{content:"";display:inline-block;width:16px;height:16px;margin-right:8px;vertical-align:text-bottom;background-color:currentColor;-webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;-webkit-mask-size:contain;mask-size:contain;transition:transform 0.2s ease, opacity 0.2s ease}body.rainbow-folders .nav-file-title-content::before{width:14px;height:14px;opacity:0.6}body.rainbow-folders .nav-file-title:hover .nav-file-title-content::before{opacity:0.9}body.rainbow-folders .nav-folder-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z'/%3E%3C/svg%3E");opacity:0.8}body.rainbow-folders .nav-folder:not(.is-collapsed) > .nav-folder-title .nav-folder-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2'/%3E%3C/svg%3E");opacity:1}body.rainbow-folders .nav-file-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E")}body.rainbow-folders .nav-file-title[data-path$=".png" i] .nav-file-title-content::before,body.rainbow-folders .nav-file-title[data-path$=".jpg" i] .nav-file-title-content::before,body.rainbow-folders .nav-file-title[data-path$=".jpeg" i] .nav-file-title-content::before,body.rainbow-folders .nav-file-title[data-path$=".gif" i] .nav-file-title-content::before,body.rainbow-folders .nav-file-title[data-path$=".svg" i] .nav-file-title-content::before,body.rainbow-folders .nav-file-title[data-path$=".webp" i] .nav-file-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='3' rx='2' ry='2'/%3E%3Ccircle cx='9' cy='9' r='2'/%3E%3Cpath d='m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='3' rx='2' ry='2'/%3E%3Ccircle cx='9' cy='9' r='2'/%3E%3Cpath d='m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21'/%3E%3C/svg%3E")}body.rainbow-folders .nav-file-title[data-path$=".canvas" i] .nav-file-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='7' height='9' x='3' y='3' rx='1'/%3E%3Crect width='7' height='5' x='14' y='3' rx='1'/%3E%3Crect width='7' height='9' x='14' y='12' rx='1'/%3E%3Crect width='7' height='5' x='3' y='16' rx='1'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='7' height='9' x='3' y='3' rx='1'/%3E%3Crect width='7' height='5' x='14' y='3' rx='1'/%3E%3Crect width='7' height='9' x='14' y='12' rx='1'/%3E%3Crect width='7' height='5' x='3' y='16' rx='1'/%3E%3C/svg%3E")}body.rainbow-folders .nav-file-title[data-path$=".base" i] .nav-file-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E")}body.theme-light.rainbow-folders .nav-files-container > div > .nav-folder{background-color:color-mix(in srgb, var(--folder-color), transparent 96%);border-top:1px solid color-mix(in srgb, var(--folder-color), transparent 92%);border-bottom:1px solid color-mix(in srgb, var(--folder-color), transparent 92%);border-right:1px solid color-mix(in srgb, var(--folder-color), transparent 92%)}body.theme-light.rainbow-folders .nav-files-container > div > .nav-folder:hover{background-color:color-mix(in srgb, var(--folder-color), transparent 92%)}body.theme-dark.rainbow-folders .nav-files-container > div > .nav-folder{background-color:color-mix(in srgb, var(--folder-color), transparent 96%);border-top:1px solid color-mix(in srgb, var(--folder-color), transparent 95%);border-bottom:1px solid color-mix(in srgb, var(--folder-color), transparent 95%);border-right:1px solid color-mix(in srgb, var(--folder-color), transparent 95%)}body.theme-dark.rainbow-folders .nav-files-container > div > .nav-folder:hover{background-color:color-mix(in srgb, var(--folder-color), transparent 92%)}body.rainbow-folders .nav-file-title{padding:4px 8px !important;border-radius:6px;color:var(--text-muted)}body.rainbow-folders .nav-file-title:hover{background-color:var(--background-modifier-hover);color:var(--text-normal)}body.rainbow-folders .nav-file-title.is-active{background-color:var(--background-modifier-active-hover);color:var(--primary-color);font-weight:600}body.rainbow-folders .nav-file-title.is-active .nav-file-title-content::before{background-color:var(--primary-color);opacity:1}@media (hover:hover){body.rainbow-folders:not(.is-grabbing) .tree-item-self.is-clickable:hover{color:var(--folder-color);font-weight:bolder}}.nav-files-container > div > .nav-folder{margin:0 0 8px 0 !important;padding:0 !important;border-left:3px solid var(--folder-color) !important;border-radius:0 6px 6px 0;transition:background-color 0.2s ease}.nav-folder .nav-folder{border-left:none !important;background-color:transparent !important;margin:0 !important;padding:0 !important;border-radius:0}.nav-folder.is-collapsed{padding-bottom:0 !important}.nav-folder-title{padding:4px 6px !important;margin:1px 0 !important;border-radius:4px;font-weight:500;color:var(--folder-color);display:flex;align-items:center}.nav-files-container > div > .nav-folder > .nav-folder-title{padding-left:8px !important}.nav-folder .nav-folder .nav-folder-title-content{opacity:0.9}.nav-folder-title:hover{background-color:var(--background-modifier-hover)}.nav-folder-collapse-indicator,.nav-folder .collapse-icon{display:none !important}.nav-folder-title-content::before,.nav-file-title-content::before{content:"";display:inline-block;width:16px;height:16px;margin-right:8px;vertical-align:text-bottom;background-color:currentColor;-webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;-webkit-mask-size:contain;mask-size:contain;transition:transform 0.2s ease, opacity 0.2s ease}.nav-file-title-content::before{width:14px;height:14px;opacity:0.6}.nav-file-title:hover .nav-file-title-content::before{opacity:0.9}.nav-folder-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z'/%3E%3C/svg%3E");opacity:0.8}.nav-folder:not(.is-collapsed) > .nav-folder-title .nav-folder-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2'/%3E%3C/svg%3E");opacity:1}.nav-file-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E")}.nav-file-title[data-path$=".png" i] .nav-file-title-content::before,.nav-file-title[data-path$=".jpg" i] .nav-file-title-content::before,.nav-file-title[data-path$=".jpeg" i] .nav-file-title-content::before,.nav-file-title[data-path$=".gif" i] .nav-file-title-content::before,.nav-file-title[data-path$=".svg" i] .nav-file-title-content::before,.nav-file-title[data-path$=".webp" i] .nav-file-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='3' rx='2' ry='2'/%3E%3Ccircle cx='9' cy='9' r='2'/%3E%3Cpath d='m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='3' rx='2' ry='2'/%3E%3Ccircle cx='9' cy='9' r='2'/%3E%3Cpath d='m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21'/%3E%3C/svg%3E")}.nav-file-title[data-path$=".canvas" i] .nav-file-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='7' height='9' x='3' y='3' rx='1'/%3E%3Crect width='7' height='5' x='14' y='3' rx='1'/%3E%3Crect width='7' height='9' x='14' y='12' rx='1'/%3E%3Crect width='7' height='5' x='3' y='16' rx='1'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='7' height='9' x='3' y='3' rx='1'/%3E%3Crect width='7' height='5' x='14' y='3' rx='1'/%3E%3Crect width='7' height='9' x='14' y='12' rx='1'/%3E%3Crect width='7' height='5' x='3' y='16' rx='1'/%3E%3C/svg%3E")}.nav-file-title[data-path$=".base" i] .nav-file-title-content::before{-webkit-mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E");mask-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E")}.nav-file-title{padding:4px 8px !important;border-radius:6px;color:var(--text-muted)}.nav-file-title:hover{background-color:var(--background-modifier-hover);color:var(--text-normal)}.nav-file-title.is-active{background-color:var(--background-modifier-active-hover);color:var(--primary-color);font-weight:600}.nav-file-title.is-active .nav-file-title-content::before{background-color:var(--primary-color);opacity:1}@media (hover:hover){body:not(.is-grabbing) .tree-item-self.is-clickable:hover{color:var(--folder-color);font-weight:bolder}}.codeblock-customizer-active-line-highlight .cm-active, .codeblock-customizer-active-line-highlight-editor .cm-active{background-color:color-mix(in srgb, var(--primary-color) , transparent 95%)!important}
+/* =================================================================
+   Editor Heading Hover Effects (Toggle: editor-heading-hover)
+   Mirrors reading-mode hover animations in editing/live-preview mode.
+   Controlled by Style Settings class-toggle on body.
+   ================================================================= */
+
+/* ---------- LIGHT MODE ---------- */
+
+/* H1 centered — color + translateY */
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-1:hover {
+  color: var(--primary-color);
+  transform: translateY(-2px);
+}
+/* H1 centered — underline expand */
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-1:hover::after {
+  width: 100%;
+}
+
+/* H1 left-aligned — color */
+body.editor-heading-hover.theme-light.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1:hover {
+  color: var(--primary-color);
+  transform: translateX(5px);
+}
+/* H1 left-aligned — ::before pillar */
+body.editor-heading-hover.theme-light.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1:hover::before {
+  height: 32px;
+  margin-top: 0;
+  left: 4px;
+  width: 6px;
+  opacity: 0.3;
+  border-radius: 3px;
+}
+/* H1 left-aligned — ::after pillar */
+body.editor-heading-hover.theme-light.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1:hover::after {
+  height: 26px;
+  margin-top: 0;
+  left: 12px;
+  width: 6px;
+  border-radius: 3px;
+  box-shadow: 0 0 10px color-mix(in srgb, var(--primary-color), transparent 60%);
+}
+
+/* H2 capsule style — background shift + scale */
+body.editor-heading-hover.theme-light.h2-style-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2:hover {
+  background-position: 100% center;
+  transform: scale(1.01);
+  box-shadow: 0 8px 20px var(--h2-shadow-hover);
+}
+
+/* H2 twin style — color */
+body.editor-heading-hover.theme-light:not(.h2-style-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2:hover,
+body.editor-heading-hover.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2:hover {
+  color: var(--primary-color) !important;
+  transform: translateX(5px);
+}
+/* H2 twin style — ::before pillar */
+body.editor-heading-hover.theme-light:not(.h2-style-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2:hover::before,
+body.editor-heading-hover.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2:hover::before {
+  top: auto;
+  margin-top: 0em;
+  height: 1.4em;
+  opacity: 0.4;
+}
+/* H2 twin style — ::after pillar */
+body.editor-heading-hover.theme-light:not(.h2-style-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2:hover::after,
+body.editor-heading-hover.theme-light.h2-style-twin .markdown-source-view.mod-cm6 .HyperMD-header-2:hover::after {
+  top: auto;
+  margin-top: 0.15em;
+  height: 1.1em;
+  width: 4px;
+  opacity: 1;
+  background-color: var(--primary-color);
+}
+
+/* H3 — color */
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-3:hover {
+  color: var(--primary-color) !important;
+  padding-left: 25px;
+}
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-3:hover::before {
+  height: 24px;
+  width: 7px;
+  opacity: 1;
+  box-shadow: 0 0 0 3px var(--light-lighter);
+}
+
+/* H4 — color + translateX */
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-4:hover {
+  color: var(--light-deep) !important;
+  transform: translateX(6px);
+}
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-4:hover::before {
+  transform: translateY(-50%) scale(1.3);
+  box-shadow: 0 0 0 4px var(--light-lighter);
+}
+
+/* H5 — color + translateX */
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-5:hover {
+  color: var(--light-deep) !important;
+  transform: translateX(6px);
+}
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-5:hover::before {
+  background-color: var(--primary-color);
+  transform: translateY(-50%) scale(1.2);
+  box-shadow: 0 0 0 3px var(--light-lighter);
+}
+
+/* H6 — color + translateX */
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-6:hover {
+  color: var(--light-deep) !important;
+  transform: translateX(6px);
+}
+body.editor-heading-hover.theme-light .markdown-source-view.mod-cm6 .HyperMD-header-6:hover::before {
+  transform: translateY(-50%) scaleX(1.8);
+}
+
+/* ---------- DARK MODE ---------- */
+
+/* H1 centered — text-shadow glow */
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-1:hover {
+  text-shadow: var(--glow-shadow-text);
+}
+/* H1 centered — ::after underline glow */
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-1:hover::after {
+  width: 100%;
+  box-shadow: 0 0 15px var(--h1-underline-color);
+}
+
+/* H1 left-aligned — text-shadow */
+body.editor-heading-hover.theme-dark.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1:hover {
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+/* H1 left-aligned — ::before pillar */
+body.editor-heading-hover.theme-dark.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1:hover::before {
+  height: 32px;
+  margin-top: 0;
+  left: 4px;
+  width: 6px;
+  opacity: 0.4;
+}
+/* H1 left-aligned — ::after pillar */
+body.editor-heading-hover.theme-dark.h1-align-left .markdown-source-view.mod-cm6 .HyperMD-header-1:hover::after {
+  height: 26px;
+  margin-top: 0;
+  left: 12px;
+  width: 6px;
+  box-shadow: 0 0 15px var(--primary-color);
+}
+
+/* H2 dark-capsule — color + glow + shadow + translateY */
+body.editor-heading-hover.theme-dark.h2-style-dark-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2:hover {
+  color: var(--primary-color);
+  text-shadow: var(--glow-shadow-text);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transform: translateY(-1px);
+}
+/* H2 dark-capsule — ::after overlay opacity */
+body.editor-heading-hover.theme-dark.h2-style-dark-capsule .markdown-source-view.mod-cm6 .HyperMD-header-2:hover::after {
+  opacity: 1;
+}
+
+/* H2 dark-twin — color + glow */
+body.editor-heading-hover.theme-dark:not(.h2-style-dark-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2:hover,
+body.editor-heading-hover.theme-dark.h2-style-dark-twin .markdown-source-view.mod-cm6 .HyperMD-header-2:hover {
+  color: var(--primary-color) !important;
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+/* H2 dark-twin — ::before pillar */
+body.editor-heading-hover.theme-dark:not(.h2-style-dark-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2:hover::before,
+body.editor-heading-hover.theme-dark.h2-style-dark-twin .markdown-source-view.mod-cm6 .HyperMD-header-2:hover::before {
+  top: auto;
+  margin-top: 0em;
+  height: 1.4em;
+  opacity: 0.5;
+}
+/* H2 dark-twin — ::after pillar + glow */
+body.editor-heading-hover.theme-dark:not(.h2-style-dark-capsule) .markdown-source-view.mod-cm6 .HyperMD-header-2:hover::after,
+body.editor-heading-hover.theme-dark.h2-style-dark-twin .markdown-source-view.mod-cm6 .HyperMD-header-2:hover::after {
+  top: auto;
+  margin-top: 0.15em;
+  height: 1.1em;
+  width: 4px;
+  opacity: 1;
+  background-color: var(--primary-color);
+  box-shadow: 0 0 12px var(--primary-color);
+}
+
+/* H3 — color + text-shadow */
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-3:hover {
+  color: var(--primary-color) !important;
+  text-shadow: var(--glow-shadow-text);
+  padding-left: 25px;
+}
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-3:hover::before {
+  height: 24px;
+  width: 7px;
+  opacity: 1;
+  box-shadow: var(--glow-shadow-box);
+}
+
+/* H4 — color + text-shadow + translateX */
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-4:hover {
+  color: var(--primary-color);
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-4:hover::before {
+  transform: translateY(-50%) scale(1.2);
+  box-shadow: var(--glow-shadow-box);
+}
+
+/* H5 — color + text-shadow + translateX */
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-5:hover {
+  color: var(--primary-color);
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-5:hover::before {
+  background-color: transparent;
+  border-color: var(--primary-color);
+  box-shadow: var(--glow-shadow-box);
+  transform: translateY(-50%) scale(1.2);
+}
+
+/* H6 — color + text-shadow + translateX */
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-6:hover {
+  color: var(--primary-color);
+  text-shadow: var(--glow-shadow-text);
+  transform: translateX(5px);
+}
+body.editor-heading-hover.theme-dark .markdown-source-view.mod-cm6 .HyperMD-header-6:hover::before {
+  text-shadow: var(--glow-shadow-text);
+  transform: scaleX(1.5);
+}
+
+.markdown-preview-view ul > li::marker,
+.markdown-preview-view ol > li::marker {
+  color: var(--primary-color);
+}
+.markdown-preview-view em {
+  padding: 0 3px 0 0;
+  color: var(--secondary-color);
+}
+.markdown-preview-view ul {
+  list-style-type: disc;
+}
+.markdown-preview-view ul ul {
+  list-style-type: circle;
+}
+.markdown-preview-view ul ul ul {
+  list-style-type: square;
+}
+.markdown-preview-view ol {
+  list-style-type: decimal;
+}
+.markdown-preview-view ol ol {
+  list-style-type: lower-alpha;
+}
+.markdown-preview-view ol ol ol {
+  list-style-type: lower-roman;
+}
+.markdown-preview-view ul > li > ol {
+  padding-left: 25px;
+}
+.markdown-preview-view li {
+  position: relative;
+}
+.markdown-preview-view li::before {
+  content: "";
+  position: absolute;
+  top: calc(var(--line-height-customize) * 1em);
+  height: calc(100% - (var(--line-height-customize) * 1.5em));
+  bottom: 0;
+  left: -18px;
+  border-left: 1px solid var(--primary-color);
+  opacity: 0.5;
+  pointer-events: none;
+}
+.markdown-preview-view ul > li::before {
+  left: -0.83rem;
+}
+.markdown-preview-view > div > ul > li::before,
+.markdown-preview-view > div > ol > li::before {
+  display: none;
+}
+.markdown-preview-view li.task-list-item::before {
+  left: -0.7rem;
+  height: calc(100% - var(--line-height-customize) * 1.4em);
+}
+.markdown-rendered.show-indentation-guide li > ul::before,
+.markdown-rendered.show-indentation-guide li > ol::before {
+  display: none !important;
+  border: none !important;
+}
+.el-ol ol li {
+  margin-left: 35px;
+}
+.markdown-source-view.mod-cm6 .HyperMD-list-line {
+  --list-color: var(--text-muted);
+}
+.markdown-source-view.mod-cm6 .HyperMD-list-line-1,
+.markdown-source-view.mod-cm6 .HyperMD-list-line-2,
+.markdown-source-view.mod-cm6 .HyperMD-list-line-3,
+.markdown-source-view.mod-cm6 .HyperMD-list-line-4,
+.markdown-source-view.mod-cm6 .HyperMD-list-line-5,
+.markdown-source-view.mod-cm6 .HyperMD-list-line-6 {
+  --list-color: var(--primary-color);
+}
+.markdown-source-view.mod-cm6 .list-bullet {
+  color: transparent !important;
+  position: relative;
+  margin-right: 12px !important;
+  display: inline-block;
+}
+.markdown-source-view.mod-cm6 .list-bullet:after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(1.1);
+  height: 6px;
+  width: 6px;
+  border-radius: 50%;
+  background-color: var(--list-color) !important;
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+.markdown-source-view.mod-cm6 .HyperMD-list-line:hover .list-bullet:after {
+  transform: translate(-50%, -50%) scale(1.6);
+  box-shadow: 0 0 8px var(--list-color);
+}
+.markdown-source-view.is-live-preview {
+  --list-padding-inline-start: 0;
+}
+.markdown-source-view.mod-cm6 .cm-indent::before {
+  margin-inline-start: 3px !important;
+}
+.markdown-source-view.mod-cm6 .cm-active-indent::before {
+  opacity: 1 !important;
+  box-shadow: 0 0 8px var(--primary-color);
+  z-index: 1;
+}
+.markdown-source-view.mod-cm6 .HyperMD-list-line .task-list-item-checkbox {
+  border-color: var(--list-color) !important;
+}
+.markdown-source-view.mod-cm6
+  .HyperMD-list-line
+  .task-list-item-checkbox:checked {
+  background-color: var(--list-color) !important;
+  box-shadow: 0 0 5px var(--list-color);
+}
+.markdown-source-view.mod-cm6 .list-number {
+  color: var(--primary-color) !important;
+  font-family: "Cascadia Code", "Lucida Console", monospace !important;
+  font-weight: bold;
+  margin-right: 4px;
+}
+.image-embed[alt*="right" i],
+.image-embed[alt*="+R" i],
+.image-embed[alt*="left" i],
+.image-embed[alt*="+L" i],
+.image-embed[alt*="center" i],
+.image-embed[alt*="+C" i],
+.image-embed[alt*="banner" i] {
+  display: flex !important;
+  width: 100% !important;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.image-embed[alt*="right" i],
+.image-embed[alt*="+R" i] {
+  justify-content: flex-end;
+}
+.image-embed[alt*="left" i],
+.image-embed[alt*="+L" i] {
+  justify-content: flex-start;
+}
+.image-embed[alt*="center" i],
+.image-embed[alt*="+C" i] {
+  justify-content: center;
+}
+.image-embed[alt*="right" i] img,
+.image-embed[alt*="+R" i] img,
+.image-embed[alt*="left" i] img,
+.image-embed[alt*="+L" i] img,
+.image-embed[alt*="center" i] img,
+.image-embed[alt*="+C" i] img {
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+}
+.image-embed[alt*="banner" i] {
+  justify-content: center;
+}
+.image-embed[alt*="banner" i] img {
+  width: 100% !important;
+  max-height: 250px;
+  object-fit: cover;
+  border-radius: 12px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+}
+.markdown-preview-view ul.contains-task-list {
+  margin-left: 10px;
+}
+.markdown-preview-view ul.contains-task-list {
+  margin-left: 10px;
+}
+.markdown-preview-view input[type="checkbox"],
+.markdown-preview-view .task-list-item-checkbox {
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+  position: absolute !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  left: -1.3rem !important;
+  top: calc(
+    (var(--line-height-customize) * 1.1rem - var(--checkbox-size)) / 2
+  ) !important;
+  width: var(--checkbox-size) !important;
+  height: var(--checkbox-size) !important;
+  z-index: 10;
+  -webkit-mask-image: none !important;
+  mask-image: none !important;
+}
+.markdown-preview-view input[type="checkbox"]::before,
+.markdown-preview-view .task-list-item-checkbox::before {
+  content: "" !important;
+  display: block !important;
+  position: absolute !important;
+  inset: 0 !important;
+  width: 1.2rem !important;
+  height: 1.2rem !important;
+  border-radius: 50% !important;
+  background-color: var(--checkbox-bg-unchecked) !important;
+  border: 2px solid var(--checkbox-border-unchecked) !important;
+  box-sizing: border-box !important;
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.4);
+  z-index: 1;
+}
+.markdown-preview-view input[type="checkbox"]:checked::before,
+.markdown-preview-view .task-list-item-checkbox:checked::before {
+  border: 1px solid var(--primary-color) !important;
+  background-color: var(--checkbox-bg-checked) !important;
+  box-shadow: var(--checkbox-shadow-checked) !important;
+  animation: task-pulse 0.4s forwards;
+}
+.markdown-preview-view input[type="checkbox"]::after,
+.markdown-preview-view .task-list-item-checkbox::after {
+  content: "" !important;
+  display: block !important;
+  position: absolute !important;
+  z-index: 2 !important;
+  top: 45% !important;
+  left: 50% !important;
+  width: 0.45rem !important;
+  height: 0.25rem !important;
+  background-color: transparent !important;
+  -webkit-mask-image: none !important;
+  mask-image: none !important;
+  border: 2.5px solid var(--checkmark-color) !important;
+  border-top: 0 !important;
+  border-right: 0 !important;
+  transform: translate(-50%, -50%) rotate(-45deg) scale(0);
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.4);
+}
+.markdown-preview-view input[type="checkbox"]:checked::after,
+.markdown-preview-view .task-list-item-checkbox:checked::after {
+  opacity: 1 !important;
+  transform: translate(-50%, -50%) rotate(-45deg) scale(1) !important;
+  border-color: var(--checkmark-color) !important;
+}
+.markdown-preview-view .task-list-item[data-task="/"] {
+  color: var(--text-normal) !important;
+  text-decoration: none !important;
+  opacity: 1 !important;
+}
+.markdown-preview-view .task-list-item[data-task="/"] p,
+.markdown-preview-view .task-list-item[data-task="/"] strong,
+.markdown-preview-view .task-list-item[data-task="/"] em,
+.markdown-preview-view .task-list-item[data-task="/"] code {
+  text-decoration: none !important;
+  color: inherit !important;
+}
+.markdown-preview-view
+  .task-list-item[data-task="/"]
+  input[type="checkbox"]:checked::after {
+  content: "" !important;
+  border: none !important;
+  width: 6px !important;
+  height: 6px !important;
+  border-radius: 50% !important;
+  background-color: var(--checkmark-color) !important;
+  top: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
+}
+.markdown-preview-view .task-list-item[data-task="-"] {
+  color: var(--text-muted) !important;
+  text-decoration: line-through !important;
+  opacity: 0.7 !important;
+}
+.markdown-preview-view .task-list-item[data-task="-"] strong,
+.markdown-preview-view .task-list-item[data-task="-"] em {
+  text-decoration: line-through !important;
+  color: inherit !important;
+}
+.markdown-preview-view
+  .task-list-item[data-task="-"]
+  input[type="checkbox"]:checked::before {
+  background-color: var(--text-muted) !important;
+  border-color: var(--text-muted) !important;
+  box-shadow: none !important;
+}
+.markdown-preview-view
+  .task-list-item[data-task="-"]
+  input[type="checkbox"]:checked::after {
+  content: "\2715" !important;
+  border: none !important;
+  transform: none !important;
+  background: transparent !important;
+  font-size: 13px !important;
+  font-weight: 800 !important;
+  color: #ffffff !important;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 100% !important;
+  height: 100% !important;
+  top: -1px !important;
+  left: -0.3px !important;
+}
+@keyframes task-pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+.markdown-preview-view .task-list-item {
+  position: relative;
+  list-style: none;
+  padding-left: 4px;
+  min-height: calc(var(--line-height-customize) * 1em);
+  transition:
+    color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),
+    opacity 0.4s cubic-bezier(0.25, 0.8, 0.25, 1),
+    text-decoration-color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1) !important;
+  text-decoration: line-through !important;
+  text-decoration-color: transparent !important;
+  text-decoration-thickness: 2px !important;
+}
+.markdown-preview-view .task-list-item.is-checked {
+  color: #888 !important;
+  opacity: 0.8;
+  text-decoration-color: var(--text-color-secondary) !important;
+}
+.markdown-preview-view .task-list-item.is-checked p,
+.markdown-preview-view .task-list-item.is-checked strong,
+.markdown-preview-view .task-list-item.is-checked em,
+.markdown-preview-view .task-list-item.is-checked mark,
+.markdown-preview-view .task-list-item.is-checked code {
+  text-decoration: line-through !important;
+  text-decoration-color: var(--text-color-secondary) !important;
+  text-decoration-thickness: 2px !important;
+  color: inherit !important;
+  opacity: 1 !important;
+}
+.markdown-preview-view blockquote p,
+.HyperMD-quote.HyperMD-quote-1.cm-line {
+  line-height: var(--blockquote-line-height);
+}
+.theme-dark .markdown-preview-view blockquote {
+  position: relative;
+  margin: 20px 0;
+  padding: 18px 20px 18px 48px;
+  color: var(--text-color-secondary);
+  background-color: rgba(0, 0, 0, 0.2);
+  border: 1px solid color-mix(in srgb, var(--secondary-color), transparent 70%);
+  border-radius: 16px;
+  transition: all 0.3s ease;
+}
+.theme-dark .markdown-preview-view blockquote::before {
+  content: "💡";
+  position: absolute;
+  left: 14px;
+  top: 18px;
+  font-size: 20px;
+  line-height: 1;
+  filter: grayscale(1);
+  opacity: 0.8;
+  transform: rotate(30deg);
+  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.theme-dark .markdown-preview-view blockquote p {
+  color: var(--text-color-secondary);
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-bottom: 0.5em;
+}
+.theme-dark .markdown-preview-view blockquote p:last-child {
+  margin-bottom: 0;
+}
+.theme-dark .markdown-preview-view blockquote:hover {
+  border-color: var(--primary-color);
+  background-color: color-mix(
+    in srgb,
+    var(--hover-background-color),
+    transparent 95%
+  );
+  box-shadow:
+    0 0 15px color-mix(in srgb, var(--hover-background-color), transparent 90%),
+    inset 0 0 10px
+      color-mix(in srgb, var(--hover-background-color), transparent 95%);
+  transform: scale(1.01);
+}
+.theme-dark .markdown-preview-view blockquote:hover::before {
+  filter: grayscale(0);
+  opacity: 1;
+  transform: rotate(0deg);
+  text-shadow: 0 0 10px var(--primary-color);
+}
+.theme-light .markdown-preview-view blockquote {
+  position: relative;
+  margin: 20px 0;
+  padding: 18px 20px 18px 48px;
+  background-color: var(--blockquote-background-color);
+  border: 1px solid color-mix(in srgb, var(--primary-color), transparent 80%);
+  border-radius: 16px;
+  color: var(--text-muted);
+  transition:
+    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    background-color 0.3s ease,
+    box-shadow 0.3s ease,
+    border-color 0.3s ease;
+}
+.theme-light .markdown-preview-view blockquote::before {
+  content: "✨";
+  position: absolute;
+  left: 14px;
+  top: 18px;
+  font-size: 20px;
+  line-height: 1;
+  font-family: "Segoe UI Emoji", "Apple Color Emoji", sans-serif;
+  filter: none;
+  opacity: 1;
+  transform: rotate(30deg);
+  transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.theme-light .markdown-preview-view blockquote p {
+  color: var(--text-muted);
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-bottom: 0.5em;
+}
+.theme-light .markdown-preview-view blockquote p:last-child {
+  margin-bottom: 0;
+}
+.theme-light .markdown-preview-view blockquote:hover {
+  transform: scale(1.02);
+  background-color: color-mix(in srgb, var(--primary-color), white 92%);
+  border-color: var(--primary-color);
+  box-shadow: 0 8px 20px
+    color-mix(in srgb, var(--primary-color), transparent 85%);
+}
+.theme-light .markdown-preview-view blockquote:hover::before {
+  transform: rotate(0deg);
+  text-shadow: 0 0 8px var(--primary-color);
+}
+.markdown-preview-view a.internal-link,
+.markdown-preview-view a.external-link,
+.markdown-source-view.mod-cm6 .cm-link .cm-underline,
+.markdown-source-view.mod-cm6 .cm-table-widget a {
+  color: var(--secondary-color) !important;
+  text-decoration: none !important;
+  font-weight: 500;
+  padding: 0 2px;
+  margin: 0;
+  border-radius: 4px;
+  position: relative;
+  border-bottom: none !important;
+  background-image: none !important;
+  padding-right: 2px !important;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+.markdown-preview-view a.internal-link::before,
+.markdown-preview-view a.external-link::before,
+.markdown-source-view.mod-cm6 .cm-link .cm-underline::before,
+.markdown-source-view.mod-cm6 .cm-table-widget a::before {
+  content: "[";
+  display: inline-block;
+  color: var(--text-muted);
+  margin-right: 1px;
+  opacity: 0.7;
+  transition:
+    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    color 0.3s,
+    opacity 0.3s;
+}
+.markdown-preview-view a.internal-link::after,
+.markdown-preview-view a.external-link::after,
+.markdown-source-view.mod-cm6 .cm-link .cm-underline::after,
+.markdown-source-view.mod-cm6 .cm-table-widget a::after {
+  content: "]";
+  display: inline-block;
+  color: var(--text-muted);
+  margin-left: 1px;
+  opacity: 0.7;
+  transition:
+    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    color 0.3s,
+    opacity 0.3s;
+}
+.markdown-preview-view a.internal-link:hover,
+.markdown-preview-view a.external-link:hover,
+.markdown-source-view.mod-cm6 .cm-link .cm-underline:hover,
+.markdown-source-view.mod-cm6 .cm-table-widget a:hover {
+  background-color: color-mix(in srgb, var(--primary-color), transparent 90%);
+  color: var(--primary-color) !important;
+  text-decoration: none !important;
+}
+.markdown-preview-view a.internal-link:hover::before,
+.markdown-preview-view a.external-link:hover::before,
+.markdown-source-view.mod-cm6 .cm-link .cm-underline:hover::before,
+.markdown-source-view.mod-cm6 .cm-table-widget a:hover::before {
+  transform: translateX(-4px);
+  color: var(--primary-color);
+  font-weight: bold;
+  opacity: 1;
+}
+.markdown-preview-view a.internal-link:hover::after,
+.markdown-preview-view a.external-link:hover::after,
+.markdown-source-view.mod-cm6 .cm-link .cm-underline:hover::after,
+.markdown-source-view.mod-cm6 .cm-table-widget a:hover::after {
+  transform: translateX(4px);
+  color: var(--primary-color);
+  font-weight: bold;
+  opacity: 1;
+}
+.markdown-preview-view .external-link-icon,
+.markdown-source-view.mod-cm6 .cm-link .external-link,
+.markdown-source-view.mod-cm6 .cm-formatting-link-string.external-link,
+.markdown-source-view.mod-cm6 .cm-url.external-link {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+  content: none !important;
+  background-image: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+/* =================================================================
+   Editor Wikilink bracket decoration & hover effects
+   Mirrors the reading-mode a.internal-link styling for cm-hmd-internal-link.
+   Gated behind Style Settings toggle: editor-wikilink-style
+   ================================================================= */
+body.editor-wikilink-style .markdown-source-view.mod-cm6 .cm-hmd-internal-link {
+  color: var(--secondary-color);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 0 2px;
+  margin: 0;
+  border-radius: 4px;
+  position: relative;
+  border-bottom: none;
+  background-image: none;
+  padding-right: 2px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+body.editor-wikilink-style .markdown-source-view.mod-cm6 .cm-hmd-internal-link::before {
+  content: "[";
+  display: inline-block;
+  color: var(--text-muted);
+  margin-right: 1px;
+  opacity: 0.7;
+  transition:
+    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    color 0.3s,
+    opacity 0.3s;
+}
+body.editor-wikilink-style .markdown-source-view.mod-cm6 .cm-hmd-internal-link::after {
+  content: "]";
+  display: inline-block;
+  color: var(--text-muted);
+  margin-left: 1px;
+  opacity: 0.7;
+  transition:
+    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    color 0.3s,
+    opacity 0.3s;
+}
+body.editor-wikilink-style .markdown-source-view.mod-cm6 .cm-hmd-internal-link:hover {
+  background-color: color-mix(in srgb, var(--primary-color), transparent 90%);
+  color: var(--primary-color);
+  text-decoration: none;
+}
+body.editor-wikilink-style .markdown-source-view.mod-cm6 .cm-hmd-internal-link:hover::before {
+  transform: translateX(-4px);
+  color: var(--primary-color);
+  font-weight: bold;
+  opacity: 1;
+}
+body.editor-wikilink-style .markdown-source-view.mod-cm6 .cm-hmd-internal-link:hover::after {
+  transform: translateX(4px);
+  color: var(--primary-color);
+  font-weight: bold;
+  opacity: 1;
+}
+/* Hide our decorative brackets when Obsidian reveals raw [[ ]] formatting marks (cursor inside link) */
+body.editor-wikilink-style .markdown-source-view.mod-cm6 .cm-formatting-link + .cm-hmd-internal-link::before {
+  display: none;
+}
+body.editor-wikilink-style .markdown-source-view.mod-cm6 .cm-hmd-internal-link:has(+ .cm-formatting-link)::after {
+  display: none;
+}
+
+.markdown-preview-view table td a,
+.markdown-source-view.mod-cm6 .cm-table-widget a {
+  padding: 0 2px !important;
+}
+.markdown-preview-view mark,
+.markdown-source-view.mod-cm6 mark,
+.markdown-source-view.mod-cm6 .cm-highlight {
+  padding: 0 2px;
+  margin: 0;
+  border-radius: 4px;
+  font-weight: inherit;
+  color: inherit;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+.markdown-preview-view mark::before,
+.markdown-preview-view mark::after,
+.markdown-source-view.mod-cm6 mark::before,
+.markdown-source-view.mod-cm6 mark::after,
+.markdown-source-view.mod-cm6 .cm-highlight::before,
+.markdown-source-view.mod-cm6 .cm-highlight::after {
+  content: none !important;
+  display: none !important;
+}
+.markdown-preview-view mark:not([style*="background"]),
+.markdown-source-view.mod-cm6 mark:not([style*="background"]),
+.markdown-source-view.mod-cm6 .cm-highlight:not([style*="background"]) {
+  background-color: transparent !important;
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  transition:
+    background-size 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+    color 0.3s ease,
+    text-shadow 0.3s ease,
+    box-shadow 0.3s ease;
+}
+body.theme-light .markdown-preview-view mark:not([style*="background"]),
+body.theme-light .markdown-source-view.mod-cm6 mark:not([style*="background"]),
+body.theme-light
+  .markdown-source-view.mod-cm6
+  .cm-highlight:not([style*="background"]) {
+  background-image: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--text-highlight), transparent 60%),
+    transparent
+  );
+  background-size: 100% 40%;
+  color: var(--text-normal);
+}
+body.theme-light .markdown-preview-view mark:not([style*="background"]):hover,
+body.theme-light
+  .markdown-source-view.mod-cm6
+  mark:not([style*="background"]):hover,
+body.theme-light
+  .markdown-source-view.mod-cm6
+  .cm-highlight:not([style*="background"]):hover {
+  background-size: 100% 100%;
+  background-image: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--text-highlight), transparent 40%),
+    color-mix(in srgb, var(--text-highlight), transparent 80%)
+  );
+}
+body.theme-dark .markdown-preview-view mark:not([style*="background"]),
+body.theme-dark .markdown-source-view.mod-cm6 mark:not([style*="background"]),
+body.theme-dark
+  .markdown-source-view.mod-cm6
+  .cm-highlight:not([style*="background"]) {
+  background-image: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--text-highlight), transparent 50%),
+    transparent
+  ) !important;
+  background-size: 100% 40%;
+  color: color-mix(in srgb, var(--text-highlight), white 20%) !important;
+  text-shadow: none;
+  box-shadow: none;
+}
+body.theme-dark .markdown-preview-view mark:not([style*="background"]):hover,
+body.theme-dark
+  .markdown-source-view.mod-cm6
+  mark:not([style*="background"]):hover,
+body.theme-dark
+  .markdown-source-view.mod-cm6
+  .cm-highlight:not([style*="background"]):hover {
+  background-size: 100% 100%;
+  background-image: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--text-highlight), transparent 20%),
+    color-mix(in srgb, var(--text-highlight), transparent 80%)
+  ) !important;
+  color: #fff !important;
+  text-shadow: 0 0 10px var(--text-highlight);
+  box-shadow: 0 0 15px color-mix(in srgb, var(--text-highlight), transparent 80%);
+  transform: none;
+}
+.markdown-preview-view strong,
+.markdown-source-view.mod-cm6 .cm-strong,
+.markdown-source-view.mod-cm6 strong {
+  font-weight: bold;
+  display: inline;
+  position: relative;
+  border-bottom: 2px solid transparent;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+  transition:
+    border-color 0.3s ease,
+    color 0.3s ease,
+    text-shadow 0.3s ease;
+}
+body.theme-dark .markdown-preview-view strong,
+body.theme-dark .markdown-source-view.mod-cm6 .cm-strong,
+body.theme-dark .markdown-source-view.mod-cm6 strong {
+  color: var(--bold-dark-color, var(--primary-color));
+}
+body.theme-dark .markdown-preview-view strong:hover,
+body.theme-dark .markdown-source-view.mod-cm6 .cm-strong:hover,
+body.theme-dark .markdown-source-view.mod-cm6 strong:hover {
+  border-bottom-color: var(--primary-color);
+  text-shadow: 0 0 10px var(--primary-color);
+  z-index: 1;
+}
+body.theme-light .markdown-preview-view strong,
+body.theme-light .markdown-source-view.mod-cm6 .cm-strong,
+body.theme-light .markdown-source-view.mod-cm6 strong {
+  color: var(--text-bold);
+}
+body.theme-light .markdown-preview-view strong:hover,
+body.theme-light .markdown-source-view.mod-cm6 .cm-strong:hover,
+body.theme-light .markdown-source-view.mod-cm6 strong:hover {
+  color: var(--primary-color) !important;
+  border-bottom-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 70%
+  );
+  text-shadow: 0 2px 10px
+    color-mix(in srgb, var(--primary-color), transparent 60%);
+}
+.markdown-preview-view em,
+.markdown-source-view.mod-cm6 .cm-em,
+.markdown-source-view.mod-cm6 em {
+  font-style: italic;
+  text-decoration: none !important;
+  padding-bottom: 1px;
+  background-repeat: repeat-x;
+  background-position: 0 100%;
+  background-size: 6px 3px;
+  transition:
+    color 0.2s ease,
+    -webkit-text-stroke 0.2s ease,
+    background-image 0.2s ease;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+.markdown-preview-view em::after,
+.markdown-source-view.mod-cm6 .cm-em::after,
+.markdown-source-view.mod-cm6 em::after {
+  content: none !important;
+  display: none !important;
+}
+@keyframes stitchFlow {
+  from {
+    background-position-x: 0;
+  }
+  to {
+    background-position-x: 6px;
+  }
+}
+body.theme-light .markdown-preview-view em,
+body.theme-light .markdown-source-view.mod-cm6 .cm-em,
+body.theme-light .markdown-source-view.mod-cm6 em {
+  color: var(--text-italic);
+  background-image: linear-gradient(
+    -45deg,
+    transparent 35%,
+    color-mix(in srgb, var(--text-italic), transparent 60%) 35%,
+    color-mix(in srgb, var(--text-italic), transparent 60%) 65%,
+    transparent 65%
+  );
+}
+body.theme-light .markdown-preview-view em:hover,
+body.theme-light .markdown-source-view.mod-cm6 .cm-em:hover,
+body.theme-light .markdown-source-view.mod-cm6 em:hover {
+  color: var(--primary-color);
+  background-image: linear-gradient(
+    -45deg,
+    transparent 35%,
+    var(--primary-color) 35%,
+    var(--primary-color) 65%,
+    transparent 65%
+  );
+  font-weight: normal;
+  -webkit-text-stroke: 0.6px var(--primary-color);
+  animation: stitchFlow 0.5s linear infinite;
+}
+body.theme-dark .markdown-preview-view em,
+body.theme-dark .markdown-source-view.mod-cm6 .cm-em,
+body.theme-dark .markdown-source-view.mod-cm6 em {
+  color: var(--italic-dark-color, var(--secondary-color));
+  background-image: linear-gradient(
+    -45deg,
+    transparent 35%,
+    color-mix(in srgb, var(--italic-dark-color, var(--secondary-color)), white 20%) 35%,
+    color-mix(in srgb, var(--italic-dark-color, var(--secondary-color)), white 20%) 65%,
+    transparent 65%
+  );
+}
+body.theme-dark .markdown-preview-view em:hover,
+body.theme-dark .markdown-source-view.mod-cm6 .cm-em:hover,
+body.theme-dark .markdown-source-view.mod-cm6 em:hover {
+  color: var(--primary-color);
+  background-image: linear-gradient(
+    -45deg,
+    transparent 35%,
+    var(--primary-color) 35%,
+    var(--primary-color) 65%,
+    transparent 65%
+  );
+  font-weight: normal;
+  -webkit-text-stroke: 0.5px var(--primary-color);
+  text-shadow: var(--glow-shadow-text);
+  animation: stitchFlow 0.5s linear infinite;
+}
+.markdown-preview-view s,
+.markdown-preview-view del,
+.markdown-source-view.mod-cm6 .cm-strikethrough {
+  text-decoration: line-through;
+  transition: all 0.3s ease;
+}
+body.theme-dark .markdown-preview-view s,
+body.theme-dark .markdown-preview-view del,
+body.theme-dark .markdown-source-view.mod-cm6 .cm-strikethrough {
+  text-decoration-color: var(--primary-color);
+  color: #888;
+}
+body.theme-dark .markdown-preview-view s:hover,
+body.theme-dark .markdown-preview-view del:hover,
+body.theme-dark .markdown-source-view.mod-cm6 .cm-strikethrough:hover {
+  opacity: 1;
+  color: var(--primary-color) !important;
+  text-decoration-color: var(--secondary-color);
+  cursor: not-allowed;
+  text-shadow: 0 0 8px var(--primary-color);
+}
+body.theme-light .markdown-preview-view s,
+body.theme-light .markdown-preview-view del,
+body.theme-light .markdown-source-view.mod-cm6 .cm-strikethrough {
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 40%
+  );
+  color: #999;
+}
+body.theme-light .markdown-preview-view s:hover,
+body.theme-light .markdown-preview-view del:hover,
+body.theme-light .markdown-source-view.mod-cm6 .cm-strikethrough:hover {
+  opacity: 1;
+  color: var(--text-normal) !important;
+  text-decoration-color: #ff5555;
+  cursor: not-allowed;
+  text-shadow: none;
+}
+.markdown-preview-view hr {
+  border: none;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--primary-color),
+    transparent
+  );
+  position: relative;
+  overflow: visible;
+  opacity: 0.5;
+  transition: all 0.3s ease;
+}
+.markdown-preview-view hr::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--primary-color);
+  background-color: var(--bg-color);
+  box-sizing: border-box;
+  transition: all 0.3s ease;
+}
+.markdown-preview-view hr:hover {
+  opacity: 1;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--primary-color),
+    transparent
+  );
+}
+.markdown-preview-view hr:hover::after {
+  border-color: var(--primary-color);
+  background-color: var(--primary-color);
+  box-shadow: 0 0 10px var(--primary-color);
+  transform: translate(-50%, -50%) rotate(225deg) scale(1.5);
+}
+.markdown-preview-view table {
+  border-collapse: separate !important;
+  border-spacing: 0 !important;
+  width: 100%;
+  margin: 1.5em 0;
+  border: 1px solid var(--border-color);
+  border-radius: var(--table-border-radius);
+  overflow: hidden;
+  background-color: var(--table-bg);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  line-height: var(--table-line-height);
+}
+.markdown-preview-view table th,
+.markdown-preview-view table td {
+  padding: 10px 15px;
+  color: var(--text-color);
+  border-top: none !important;
+  border-left: none !important;
+  border-right: 1px solid var(--table-border-inner);
+  border-bottom: 1px solid var(--table-border-inner);
+  transition: all 0.2s ease;
+}
+.markdown-preview-view table th:last-child,
+.markdown-preview-view table td:last-child {
+  border-right: none !important;
+}
+.markdown-preview-view table tr:last-child td {
+  border-bottom: none !important;
+}
+.markdown-preview-view table th {
+  background-color: var(--table-th-bg) !important;
+  color: var(--primary-color);
+  font-weight: bold;
+  white-space: nowrap;
+  border-right: 1px solid var(--table-th-border) !important;
+  border-bottom: 1px solid var(--table-th-border) !important;
+}
+.markdown-preview-view table th:last-child {
+  border-right: none !important;
+}
+.markdown-preview-view table tbody tr:hover td {
+  background-color: var(--table-row-hover-bg);
+}
+.markdown-preview-view table tbody td:hover {
+  background-color: var(--table-cell-hover-bg);
+  color: var(--table-cell-hover-text);
+  box-shadow: inset 0 0 0 1px var(--primary-color);
+  cursor: default;
+}
+.markdown-preview-view table tr:nth-child(2n),
+.markdown-preview-view table tr:nth-child(2n + 1) {
+  background-color: transparent !important;
+}
+.markdown-preview-view table thead tr,
+.markdown-preview-view table thead tr:nth-child(2n),
+.markdown-preview-view table thead tr:nth-child(2n + 1) {
+  background-color: transparent !important;
+}
+.markdown-preview-view table th {
+  background-color: var(--table-th-bg) !important;
+}
+.theme-dark .markdown-preview-view table tbody td:hover {
+  text-shadow: 0 0 8px var(--primary-color);
+}
+.theme-light .markdown-preview-view table tbody td:hover {
+  text-shadow: none;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget .table-editor {
+  background-color: var(--table-bg) !important;
+  border: 1px solid var(--border-color) !important;
+  border-radius: var(--table-border-radius);
+  border-collapse: separate !important;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  width: 100%;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget thead th {
+  background-color: var(--table-th-bg) !important;
+  color: var(--primary-color) !important;
+  font-weight: bold;
+  border-bottom: 1px solid var(--table-th-border) !important;
+  border-right: 1px solid var(--table-th-border) !important;
+  border-top: none !important;
+  border-left: none !important;
+  position: relative;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget tbody td {
+  border-right: 1px solid var(--table-border-inner) !important;
+  border-bottom: 1px solid var(--table-border-inner) !important;
+  border-top: none !important;
+  border-left: none !important;
+  color: var(--text-color);
+  transition: background-color 0.2s ease;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget .table-cell-wrapper {
+  padding: 10px 15px !important;
+  display: block;
+  min-height: 100%;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget th:last-child,
+.markdown-source-view.mod-cm6 .cm-table-widget td:last-child {
+  border-right: none !important;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget tbody tr:last-child td {
+  border-bottom: none !important;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget tbody tr:hover td {
+  background-color: var(--table-row-hover-bg);
+}
+.markdown-source-view.mod-cm6 .cm-table-widget tbody td:hover {
+  background-color: var(--table-cell-hover-bg) !important;
+  box-shadow: inset 0 0 0 1px var(--primary-color) !important;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget .table-col-drag-handle,
+.markdown-source-view.mod-cm6 .cm-table-widget .table-row-drag-handle {
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  background-color: color-mix(in srgb, var(--border-color), transparent 70%);
+}
+.markdown-source-view.mod-cm6 .cm-table-widget th:hover .table-col-drag-handle,
+.markdown-source-view.mod-cm6 .cm-table-widget th:hover .table-row-drag-handle,
+.markdown-source-view.mod-cm6 .cm-table-widget td:hover .table-row-drag-handle {
+  opacity: 1;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget .table-row-btn,
+.markdown-source-view.mod-cm6 .cm-table-widget .table-col-btn {
+  color: var(--text-muted);
+  transition: all 0.2s ease;
+  background-color: transparent;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget .table-row-btn {
+  width: 97%;
+}
+.markdown-source-view.mod-cm6 .cm-table-widget .table-row-btn:hover,
+.markdown-source-view.mod-cm6 .cm-table-widget .table-col-btn:hover {
+  border: none;
+  color: var(--primary-color);
+  background-color: transparent;
+  transform: scale(1.1);
+}
+.markdown-source-view.mod-cm6 .cm-table-widget .cm-active {
+  background-color: transparent !important;
+}
+.markdown-rendered button.copy-code-button {
+  top: -4px;
+}
+.markdown-preview-view pre {
+  position: relative;
+  background-color: var(--code-background) !important;
+  border: 1px solid color-mix(in srgb, var(--border-color), transparent 50%) !important;
+  border-radius: var(--code-radius);
+  padding-top: 38px !important;
+  padding-bottom: 12px;
+  padding-left: 0;
+  padding-right: 0;
+  margin: 20px 0;
+  overflow: hidden;
+  transition:
+    border-color 0.3s ease,
+    box-shadow 0.3s ease;
+}
+.markdown-preview-view pre:hover {
+  border-color: var(--primary-color) !important;
+  box-shadow: 0 4px 12px
+    color-mix(in srgb, var(--primary-color), transparent 85%);
+}
+.markdown-preview-view pre::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 32px;
+  background-color: color-mix(in srgb, var(--primary-color), transparent 96%);
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iNDUwcHgiIGhlaWdodD0iMTMwcHgiPgogIDxlbGxpcHNlIGN4PSI2NSIgY3k9IjY1IiByeD0iNTAiIHJ5PSI1MiIgc3Ryb2tlPSJyZ2IoMjIwLDYwLDU0KSIgc3Ryb2tlLXdpZHRoPSIyIiBmaWxsPSJyZ2IoMjM3LDEwOCw5NikiLz4KICA8ZWxsaXBzZSBjeD0iMjI1IiBjeT0iNjUiIHJ4PSI1MCIgcnk9IjUyIiAgc3Ryb2tlPSJyZ2IoMjE4LDE1MSwzMykiIHN0cm9rZS13aWR0aD0iMiIgZmlsbD0icmdiKDI0NywxOTMsODEpIi8+CiAgPGVsbGlwc2UgY3g9IjM4NSIgY3k9IjY1IiByeD0iNTAiIHJ5PSI1MiIgIHN0cm9rZT0icmdiKDI3LDE2MSwzNykiIHN0cm9rZS13aWR0aD0iMiIgZmlsbD0icmdiKDEwMCwyMDAsODYpIi8+Cjwvc3ZnPg==);
+  background-repeat: no-repeat;
+  background-size: 54px;
+  background-position: 12px center;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--border-color), transparent 70%);
+  border-radius: 8px 8px 0 0;
+  z-index: 5;
+}
+.markdown-preview-view pre:hover::before {
+  background-color: color-mix(in srgb, var(--primary-color), transparent 95%);
+  border-bottom-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 80%
+  );
+}
+.markdown-preview-view pre code {
+  display: block;
+  padding: 0 16px;
+  overflow-x: auto;
+  color: var(--code-normal) !important;
+  font-family: var(--font-monospace);
+  line-height: var(--code-line-height);
+  background-color: transparent !important;
+}
+.markdown-preview-view pre.language-mermaid {
+  padding-top: 0 !important;
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+.markdown-preview-view pre.language-mermaid::before {
+  display: none !important;
+}
+.markdown-preview-view .copy-code-button {
+  background-color: transparent;
+  color: var(--code-comment);
+  top: 4px;
+  right: 6px;
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 4px;
+  z-index: 10;
+  transition: all 0.2s;
+}
+.markdown-preview-view .copy-code-button:hover {
+  background-color: var(--primary-color);
+  color: #fff;
+}
+.markdown-preview-view pre:not([class]) {
+  padding-top: 12px !important;
+  padding-bottom: 12px !important;
+  padding-left: 16px !important;
+  padding-right: 16px !important;
+  background-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 96%
+  ) !important;
+  border: none !important;
+  border-left: 4px solid var(--primary-color) !important;
+  border-radius: 4px !important;
+  box-shadow: none !important;
+  margin: 16px 0;
+}
+.markdown-preview-view pre:not([class])::before {
+  content: none !important;
+  display: none !important;
+  height: 0 !important;
+  width: 0 !important;
+}
+.markdown-preview-view pre:not([class]) code {
+  color: var(--text-normal) !important;
+  font-family: var(--font-monospace);
+  padding: 0 !important;
+  background-color: transparent !important;
+  display: block;
+  white-space: pre-wrap;
+}
+body.theme-dark .markdown-preview-view pre:not([class]) {
+  background-color: rgba(255, 255, 255, 0.03) !important;
+  border-left-color: var(--primary-color) !important;
+}
+.markdown-source-view.mod-cm6 .HyperMD-codeblock {
+  font-family: var(--font-monospace) !important;
+  line-height: 1.5;
+  border-left: 1px solid var(--code-border-color, rgba(189, 147, 249, 0.3));
+  border-right: 1px solid var(--code-border-color, rgba(189, 147, 249, 0.3));
+}
+.theme-dark .markdown-source-view.mod-cm6 .HyperMD-codeblock {
+  background-color: rgba(255, 255, 255, 0.03) !important;
+  color: var(--text-normal);
+}
+.theme-light .markdown-source-view.mod-cm6 .HyperMD-codeblock {
+  background-color: var(--code-background) !important;
+  --code-border-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 85%
+  );
+  border-left: 1px solid var(--code-border-color);
+  border-right: 1px solid var(--code-border-color);
+  color: var(--code-normal) !important;
+}
+.markdown-source-view.mod-cm6 .HyperMD-codeblock-begin {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  padding-top: 6px !important;
+  padding-bottom: 6px !important;
+  margin-top: 12px;
+  position: relative;
+  font-weight: bold;
+  border-top: 1px solid var(--code-border-color, rgba(189, 147, 249, 0.3));
+}
+.theme-dark .markdown-source-view.mod-cm6 .HyperMD-codeblock-begin {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  color: var(--secondary-color) !important;
+}
+.theme-light .markdown-source-view.mod-cm6 .HyperMD-codeblock-begin {
+  background-color: var(--code-block-header-bg, #f7f7f7) !important;
+  color: var(--primary-color) !important;
+}
+.markdown-source-view.mod-cm6 .HyperMD-codeblock-end {
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--code-border-color, rgba(189, 147, 249, 0.3));
+}
+.theme-dark .markdown-source-view.mod-cm6 .HyperMD-codeblock-end {
+  color: var(--text-muted) !important;
+}
+.theme-light .markdown-source-view.mod-cm6 .HyperMD-codeblock-end {
+  color: var(--code-comment) !important;
+}
+.theme-dark .markdown-source-view.mod-cm6 .HyperMD-codeblock.cm-active {
+  background-color: rgba(255, 255, 255, 0.05) !important;
+}
+.theme-light .markdown-source-view.mod-cm6 .HyperMD-codeblock.cm-active {
+  background-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 94%
+  ) !important;
+}
+.cm-keyword {
+  color: var(--code-keyword) !important;
+}
+.cm-def {
+  color: var(--code-function) !important;
+}
+.cm-string {
+  color: var(--code-string) !important;
+}
+.cm-number {
+  color: var(--code-value) !important;
+}
+.cm-comment {
+  color: var(--code-comment) !important;
+}
+.cm-variable {
+  color: var(--code-operator) !important;
+}
+.cm-property {
+  color: var(--code-property) !important;
+}
+.cm-type {
+  color: var(--code-function) !important;
+}
+.cm-atom {
+  color: var(--code-value) !important;
+}
+.theme-light .cm-punctuation,
+.theme-light .cm-operator {
+  color: var(--code-punctuation, #555) !important;
+}
+.callout {
+  padding: 12px 16px !important;
+  margin-block: 1em !important;
+  border: none !important;
+  border-radius: 12px !important;
+  position: relative !important;
+  overflow: hidden !important;
+  mix-blend-mode: normal;
+  transition:
+    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.3s ease,
+    background-color 0.3s ease !important;
+}
+.callout:hover {
+  z-index: 5;
+}
+.callout-title {
+  display: inline-flex !important;
+  align-items: center;
+  margin-bottom: 12px !important;
+  padding: 4px 12px !important;
+  border-radius: 50px !important;
+  font-weight: 700;
+  font-size: 0.9em;
+  line-height: 1.2;
+  color: inherit !important;
+  background-color: rgba(255, 255, 255, 0.6) !important;
+  border: 1px solid rgba(0, 0, 0, 0.05) !important;
+  position: relative;
+  z-index: 2;
+}
+.callout-icon {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  margin-right: 6px !important;
+  flex: 0 0 auto !important;
+  color: currentColor !important;
+}
+.callout-icon svg {
+  width: 16px !important;
+  height: 16px !important;
+  display: block !important;
+  opacity: 1 !important;
+  fill: currentColor !important;
+  stroke: currentColor !important;
+  stroke-width: 2px;
+}
+.callout::after {
+  content: "✨";
+  position: absolute !important;
+  right: -10px !important;
+  bottom: -15px !important;
+  font-family: "Segoe UI Emoji", "Apple Color Emoji", sans-serif;
+  font-size: 80px !important;
+  line-height: 1;
+  opacity: 0.12 !important;
+  transform: rotate(-15deg);
+  filter: grayscale(100%);
+  pointer-events: none;
+  z-index: 0;
+  transition: all 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) !important;
+}
+.callout:hover::after {
+  transform: rotate(0deg) scale(1.1) !important;
+  opacity: 0.25 !important;
+  right: 0px !important;
+  bottom: -5px !important;
+  filter: grayscale(0%) !important;
+}
+.callout-content {
+  position: relative;
+  z-index: 2;
+}
+.callout-content ul.contains-task-list {
+  margin-left: 2px;
+}
+.markdown-source-view.mod-cm6
+  .callout-content
+  ul.contains-task-list
+  input.task-list-item-checkbox {
+  transform: translateY(4px);
+}
+.theme-light .callout[data-callout="note"],
+.theme-light .callout[data-callout="info"],
+.theme-light .callout[data-callout="todo"] {
+  background-color: rgba(48, 107, 214, 0.1) !important;
+}
+.theme-light .callout[data-callout="note"] .callout-title {
+  color: #6c5ce7 !important;
+}
+.theme-light .callout[data-callout="note"]:hover {
+  background-color: rgba(108, 92, 231, 0.15) !important;
+}
+.theme-light .callout[data-callout="note"]::after {
+  content: "📝";
+  color: #6c5ce7;
+}
+.theme-light .callout[data-callout="info"]::after {
+  content: "ℹ️";
+  color: #6c5ce7;
+}
+.theme-light .callout[data-callout="todo"]::after {
+  content: "✅";
+  color: #6c5ce7;
+}
+.theme-light .callout[data-callout="tip"] {
+  background-color: rgba(0, 184, 148, 0.1) !important;
+}
+.theme-light .callout[data-callout="tip"] .callout-title {
+  color: #00b894 !important;
+}
+.theme-light .callout[data-callout="tip"]:hover {
+  background-color: rgba(0, 184, 148, 0.15) !important;
+}
+.theme-light .callout[data-callout="tip"]::after {
+  content: "💡";
+  color: #00b894;
+}
+.theme-light .callout[data-callout="warning"] {
+  background-color: rgba(253, 203, 110, 0.15) !important;
+}
+.theme-light .callout[data-callout="warning"] .callout-title {
+  color: #e17055 !important;
+}
+.theme-light .callout[data-callout="warning"]:hover {
+  background-color: rgba(253, 203, 110, 0.2) !important;
+}
+.theme-light .callout[data-callout="warning"]::after {
+  content: "⚠️";
+  color: #e17055;
+}
+.theme-light .callout[data-callout="important"] {
+  background-color: rgba(255, 118, 117, 0.12) !important;
+}
+.theme-light .callout[data-callout="important"] .callout-title {
+  color: #ff7675 !important;
+}
+.theme-light .callout[data-callout="important"]:hover {
+  background-color: rgba(255, 118, 117, 0.18) !important;
+}
+.theme-light .callout[data-callout="important"]::after {
+  content: "📌";
+  color: #ff7675;
+}
+.theme-light .callout[data-callout="caution"],
+.theme-light .callout[data-callout="bug"] {
+  background-color: rgba(214, 48, 49, 0.08) !important;
+}
+.theme-light .callout[data-callout="caution"] .callout-title {
+  color: #d63031 !important;
+}
+.theme-light .callout[data-callout="caution"]:hover {
+  background-color: rgba(214, 48, 49, 0.12) !important;
+}
+.theme-light .callout[data-callout="caution"]::after {
+  content: "🔥";
+  color: #d63031;
+}
+.theme-light .callout[data-callout="success"],
+.theme-light .callout[data-callout="done"] {
+  background-color: rgba(85, 239, 196, 0.15) !important;
+}
+.theme-light .callout[data-callout="success"] .callout-title {
+  color: #00b894 !important;
+}
+.theme-light .callout[data-callout="success"]:hover {
+  background-color: rgba(85, 239, 196, 0.25) !important;
+}
+.theme-light .callout[data-callout="success"]::after {
+  content: "🎉";
+  color: #00b894;
+}
+.theme-light .callout[data-callout="example"] {
+  background-color: rgba(162, 155, 254, 0.15) !important;
+}
+.theme-light .callout[data-callout="example"] .callout-title {
+  color: #6c5ce7 !important;
+}
+.theme-light .callout[data-callout="example"]:hover {
+  background-color: rgba(162, 155, 254, 0.25) !important;
+}
+.theme-light .callout[data-callout="example"]::after {
+  content: "🧩";
+  color: #6c5ce7;
+}
+.theme-light .callout[data-callout="quote"] {
+  background-color: rgba(178, 190, 195, 0.15) !important;
+}
+.theme-light .callout[data-callout="quote"] .callout-title {
+  color: #636e72 !important;
+}
+.theme-light .callout[data-callout="quote"]:hover {
+  background-color: rgba(178, 190, 195, 0.25) !important;
+}
+.theme-light .callout[data-callout="quote"]::after {
+  content: "💬";
+  color: #636e72;
+}
+.theme-light .callout[data-callout="danger"],
+.theme-light .callout[data-callout="error"] {
+  background-color: rgba(214, 48, 49, 0.15) !important;
+  border-left-color: #d63031 !important;
+}
+.theme-light .callout[data-callout="danger"] .callout-title,
+.theme-light .callout[data-callout="error"] .callout-title {
+  color: #d63031 !important;
+}
+.theme-light .callout[data-callout="danger"]:hover,
+.theme-light .callout[data-callout="error"]:hover {
+  background-color: rgba(214, 48, 49, 0.2) !important;
+}
+.theme-light .callout[data-callout="danger"]::after {
+  content: "⚡";
+  color: #d63031;
+}
+.theme-light .callout[data-callout="error"]::after {
+  content: "❌";
+  color: #d63031;
+}
+.theme-light .callout[data-callout="bug"]::after {
+  content: "🐛";
+  color: #d63031;
+}
+.theme-light .callout[data-callout="failure"],
+.theme-light .callout[data-callout="missing"] {
+  background-color: rgba(45, 52, 54, 0.05) !important;
+}
+.theme-light .callout[data-callout="failure"] .callout-title {
+  color: #c0392b !important;
+}
+.theme-light .callout[data-callout="failure"]:hover {
+  background-color: rgba(45, 52, 54, 0.1) !important;
+}
+.theme-light .callout[data-callout="failure"]::after {
+  content: "📉";
+  color: #c0392b;
+}
+.theme-light .callout[data-callout="question"],
+.theme-light .callout[data-callout="faq"],
+.theme-light .callout[data-callout="help"] {
+  background-color: rgba(253, 203, 110, 0.15) !important;
+}
+.theme-light .callout[data-callout="question"] .callout-title {
+  color: #f39c12 !important;
+}
+.theme-light .callout[data-callout="question"]:hover {
+  background-color: rgba(253, 203, 110, 0.25) !important;
+}
+.theme-light .callout[data-callout="question"]::after {
+  content: "❓";
+  color: #f39c12;
+}
+.theme-light .callout[data-callout="abstract"],
+.theme-light .callout[data-callout="summary"],
+.theme-light .callout[data-callout="tldr"] {
+  background-color: rgba(129, 236, 236, 0.2) !important;
+}
+.theme-light .callout[data-callout="abstract"] .callout-title {
+  color: #00cec9 !important;
+}
+.theme-light .callout[data-callout="abstract"]:hover {
+  background-color: rgba(129, 236, 236, 0.3) !important;
+}
+.theme-light .callout[data-callout="abstract"]::after {
+  content: "📑";
+  color: #00cec9;
+}
+.theme-dark .callout {
+  background-color: rgba(255, 255, 255, 0.03) !important;
+  border: 1px solid rgba(255, 255, 255, 0.05) !important;
+}
+.theme-dark .callout-title {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  color: var(--text-normal) !important;
+}
+.theme-dark .callout[data-callout="note"] {
+  border-color: rgba(189, 147, 249, 0.3) !important;
+  background-color: rgba(189, 147, 249, 0.1) !important;
+}
+.theme-dark .callout[data-callout="note"] .callout-title {
+  color: #bd93f9 !important;
+}
+.theme-dark .callout[data-callout="note"]:hover {
+  background-color: rgba(189, 147, 249, 0.2) !important;
+}
+.theme-dark .callout[data-callout="note"]::after {
+  content: "📝";
+  color: #bd93f9;
+}
+.theme-dark .callout[data-callout="tip"] {
+  border-color: rgba(139, 233, 253, 0.3) !important;
+  background-color: rgba(139, 233, 253, 0.1) !important;
+}
+.theme-dark .callout[data-callout="tip"] .callout-title {
+  color: #8be9fd !important;
+}
+.theme-dark .callout[data-callout="tip"]:hover {
+  background-color: rgba(139, 233, 253, 0.2) !important;
+}
+.theme-dark .callout[data-callout="tip"]::after {
+  content: "💡";
+  color: #8be9fd;
+}
+.theme-dark .callout[data-callout="warning"] {
+  border-color: rgba(255, 184, 108, 0.3) !important;
+  background-color: rgba(255, 184, 108, 0.1) !important;
+}
+.theme-dark .callout[data-callout="warning"] .callout-title {
+  color: #ffb86c !important;
+}
+.theme-dark .callout[data-callout="warning"]:hover {
+  background-color: rgba(255, 184, 108, 0.2) !important;
+}
+.theme-dark .callout[data-callout="warning"]::after {
+  content: "⚠️";
+  color: #ffb86c;
+}
+.theme-dark .callout[data-callout="important"] {
+  border-color: rgba(255, 85, 85, 0.3) !important;
+  background-color: rgba(255, 85, 85, 0.1) !important;
+}
+.theme-dark .callout[data-callout="important"] .callout-title {
+  color: #ff5555 !important;
+}
+.theme-dark .callout[data-callout="important"]:hover {
+  background-color: rgba(255, 85, 85, 0.2) !important;
+}
+.theme-dark .callout[data-callout="important"]::after {
+  content: "🔥";
+  color: #ff5555;
+}
+.theme-dark .callout[data-callout="info"] {
+  border-color: rgba(116, 192, 252, 0.3) !important;
+  background-color: rgba(116, 192, 252, 0.1) !important;
+}
+.theme-dark .callout[data-callout="info"] .callout-title {
+  color: #74c0fc !important;
+}
+.theme-dark .callout[data-callout="info"]::after {
+  content: "ℹ️";
+  color: #74c0fc;
+}
+.theme-dark .callout[data-callout="todo"] {
+  border-color: rgba(80, 250, 123, 0.3) !important;
+  background-color: rgba(80, 250, 123, 0.1) !important;
+}
+.theme-dark .callout[data-callout="todo"] .callout-title {
+  color: #50fa7b !important;
+}
+.theme-dark .callout[data-callout="todo"]::after {
+  content: "✅";
+  color: #50fa7b;
+}
+.theme-dark .callout[data-callout="success"],
+.theme-dark .callout[data-callout="done"] {
+  border-color: rgba(85, 239, 196, 0.3) !important;
+  background-color: rgba(85, 239, 196, 0.1) !important;
+}
+.theme-dark .callout[data-callout="success"] .callout-title {
+  color: #55efc4 !important;
+}
+.theme-dark .callout[data-callout="success"]:hover {
+  background-color: rgba(85, 239, 196, 0.15) !important;
+}
+.theme-dark .callout[data-callout="success"]::after {
+  content: "🎉";
+  color: #55efc4;
+}
+.theme-dark .callout[data-callout="question"],
+.theme-dark .callout[data-callout="faq"],
+.theme-dark .callout[data-callout="help"] {
+  border-color: rgba(241, 250, 140, 0.3) !important;
+  background-color: rgba(241, 250, 140, 0.1) !important;
+}
+.theme-dark .callout[data-callout="question"] .callout-title {
+  color: #f1fa8c !important;
+}
+.theme-dark .callout[data-callout="question"]:hover {
+  background-color: rgba(241, 250, 140, 0.15) !important;
+}
+.theme-dark .callout[data-callout="question"]::after {
+  content: "❓";
+  color: #f1fa8c;
+}
+.theme-dark .callout[data-callout="example"] {
+  border-color: rgba(255, 121, 198, 0.3) !important;
+  background-color: rgba(255, 121, 198, 0.1) !important;
+}
+.theme-dark .callout[data-callout="example"] .callout-title {
+  color: #ff79c6 !important;
+}
+.theme-dark .callout[data-callout="example"]:hover {
+  background-color: rgba(255, 121, 198, 0.15) !important;
+}
+.theme-dark .callout[data-callout="example"]::after {
+  content: "🧩";
+  color: #ff79c6;
+}
+.theme-dark .callout[data-callout="quote"] {
+  border-color: rgba(223, 230, 233, 0.2) !important;
+  background-color: rgba(223, 230, 233, 0.05) !important;
+}
+.theme-dark .callout[data-callout="quote"] .callout-title {
+  color: #dfe6e9 !important;
+}
+.theme-dark .callout[data-callout="quote"]::after {
+  content: "💬";
+  color: #dfe6e9;
+}
+.theme-dark .callout[data-callout="danger"],
+.theme-dark .callout[data-callout="error"] {
+  border-color: rgba(255, 85, 85, 0.4) !important;
+  background-color: rgba(255, 85, 85, 0.1) !important;
+  box-shadow: 0 0 10px rgba(255, 85, 85, 0.1);
+}
+.theme-dark .callout[data-callout="danger"] .callout-title,
+.theme-dark .callout[data-callout="error"] .callout-title {
+  color: #ff5555 !important;
+}
+.theme-dark .callout[data-callout="danger"]::after {
+  content: "⚡";
+  color: #ff5555;
+}
+.theme-dark .callout[data-callout="error"]::after {
+  content: "❌";
+  color: #ff5555;
+}
+*/ .theme-dark .callout[data-callout="bug"] {
+  border-color: rgba(255, 85, 85, 0.4) !important;
+  background-color: rgba(255, 85, 85, 0.1) !important;
+}
+.theme-dark .callout[data-callout="bug"] .callout-title {
+  color: #ff5555 !important;
+}
+.theme-dark .callout[data-callout="bug"]::after {
+  content: "🐛";
+  color: #ff5555;
+}
+.theme-dark .callout[data-callout="failure"],
+.theme-dark .callout[data-callout="missing"] {
+  border-color: rgba(179, 57, 57, 0.3) !important;
+  background-color: rgba(0, 0, 0, 0.2) !important;
+}
+.theme-dark .callout[data-callout="failure"] .callout-title {
+  color: #fab1a0 !important;
+}
+.theme-dark .callout[data-callout="failure"]::after {
+  content: "📉";
+  color: #fab1a0;
+}
+.theme-dark .callout[data-callout="abstract"],
+.theme-dark .callout[data-callout="summary"] {
+  border-color: rgba(129, 236, 236, 0.3) !important;
+  background-color: rgba(129, 236, 236, 0.1) !important;
+}
+.theme-dark .callout[data-callout="abstract"] .callout-title {
+  color: #81ecec !important;
+}
+.theme-dark .callout[data-callout="abstract"]::after {
+  content: "📑";
+  color: #81ecec;
+}
+.markdown-source-view.mod-cm6
+  .cm-embed-block:not(.cm-table-widget, .cm-lang-base):hover {
+  box-shadow: none;
+}
+.markdown-preview-view :not(pre) > code,
+.markdown-source-view.mod-cm6 .cm-inline-code:not(.cm-formatting) {
+  font-family: var(--font-monospace) !important;
+  letter-spacing: 0.5px;
+  background-color: color-mix(in srgb, var(--primary-color), transparent 90%);
+  color: var(--primary-color) !important;
+  border: 1px solid color-mix(in srgb, var(--primary-color), transparent 85%);
+  padding: 2px 6px !important;
+  margin: 0 2px;
+  border-radius: 6px;
+  vertical-align: middle;
+  transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+.markdown-preview-view :not(pre) > code:hover {
+  background-color: var(--primary-color) !important;
+  color: #fff !important;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 15px color-mix(in srgb, var(--primary-color), transparent 60%);
+  transform: scale(1.05);
+  text-decoration: none !important;
+  -webkit-text-fill-color: #fff !important;
+  position: relative;
+  z-index: 1;
+}
+.markdown-source-view.mod-cm6 .cm-formatting-code {
+  color: var(--primary-color) !important;
+  opacity: 0.4;
+  font-family: var(--font-monospace);
+  font-weight: bold;
+}
+.markdown-preview-view kbd,
+.markdown-source-view.mod-cm6 .cm-kbd,
+.markdown-source-view.mod-cm6 kbd {
+  font-family: var(--font-monospace), "CascadiaCode", Consolas, monospace;
+  font-size: 0.9em;
+  font-weight: 600;
+  line-height: 1;
+  text-align: center;
+  display: inline-block;
+  min-width: 1.6em;
+  padding: 3px 6px;
+  margin: 0 4px;
+  border-radius: 6px;
+  vertical-align: middle;
+  transition: all 0.15s cubic-bezier(0.25, 0.8, 0.25, 1);
+  text-shadow: none;
+  cursor: default;
+}
+body.theme-dark .markdown-preview-view kbd,
+body.theme-dark .markdown-source-view.mod-cm6 .cm-kbd,
+body.theme-dark .markdown-source-view.mod-cm6 kbd {
+  background-color: #333;
+  color: var(--text-color);
+  border: 1px solid #444;
+  border-top-color: #555;
+  border-bottom-color: #222;
+  box-shadow:
+    0 4px 0 #222,
+    0 5px 5px rgba(0, 0, 0, 0.4);
+}
+body.theme-dark .markdown-preview-view kbd:hover,
+body.theme-dark .markdown-source-view.mod-cm6 .cm-kbd:hover,
+body.theme-dark .markdown-source-view.mod-cm6 kbd:hover {
+  transform: translateY(2px);
+  box-shadow:
+    0 2px 0 #222,
+    0 3px 3px rgba(0, 0, 0, 0.4);
+  color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+body.theme-light .markdown-preview-view kbd,
+body.theme-light .markdown-source-view.mod-cm6 .cm-kbd,
+body.theme-light .markdown-source-view.mod-cm6 kbd {
+  background-color: #fff;
+  color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  border-bottom-width: 3px;
+  box-shadow: 0 2px 4px
+    color-mix(in srgb, var(--primary-color), transparent 85%);
+}
+body.theme-light .markdown-preview-view kbd:hover,
+body.theme-light .markdown-source-view.mod-cm6 .cm-kbd:hover,
+body.theme-light .markdown-source-view.mod-cm6 kbd:hover {
+  transform: translateY(2px);
+  border-bottom-width: 1px;
+  background-color: color-mix(in srgb, var(--primary-color), transparent 90%);
+  box-shadow: none;
+}
+.mermaid {
+  display: block !important;
+  width: 100% !important;
+  overflow-x: auto !important;
+  overflow-y: hidden;
+  margin: 1em 0;
+  padding-bottom: 8px;
+  text-align: center;
+  background-color: transparent !important;
+}
+.mermaid .node rect,
+.mermaid .node circle,
+.mermaid .node ellipse,
+.mermaid .node path {
+  fill: color-mix(in srgb, var(--primary-color), transparent 90%) !important;
+  stroke: var(--primary-color) !important;
+  stroke-width: 1.5px !important;
+  opacity: 1 !important;
+}
+.mermaid .node polygon {
+  fill: color-mix(in srgb, var(--secondary-color), transparent 85%) !important;
+  stroke: var(--secondary-color) !important;
+  stroke-width: 1.5px !important;
+}
+.mermaid .label,
+.mermaid foreignObject,
+.mermaid foreignObject div,
+.mermaid foreignObject span,
+.mermaid foreignObject p,
+.mermaid span.nodeLabel {
+  color: var(--mermaid-text-color) !important;
+  fill: #ffffff !important;
+  background-color: transparent !important;
+  background: none !important;
+  border: none !important;
+  box-shadow: none !important;
+  font-size: 12px !important;
+  line-height: 1.5 !important;
+  font-weight: 500 !important;
+}
+.mermaid foreignObject {
+  overflow: visible !important;
+}
+.mermaid .node .label,
+.mermaid .label {
+  stroke: none !important;
+}
+.mermaid .edgePath .path,
+.mermaid .flowchart-link {
+  stroke: #999 !important;
+  stroke-width: 1.5px !important;
+  opacity: 1 !important;
+}
+.mermaid .marker path,
+.mermaid marker path {
+  fill: #e0e0e0 !important;
+  stroke: #e0e0e0 !important;
+}
+.mermaid .edgeLabel .label rect {
+  fill: #2e2e2e !important;
+  opacity: 1 !important;
+  rx: 4px;
+}
+.mermaid .edgeLabel .label {
+  background-color: #2e2e2e !important;
+}
+.mermaid::-webkit-scrollbar {
+  height: 6px;
+}
+.mermaid::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 3px;
+}
+.mermaid::-webkit-scrollbar-thumb {
+  background: var(--primary-color);
+  border-radius: 3px;
+}
+.mermaid::-webkit-scrollbar-thumb:hover {
+  background: var(--secondary-color);
+}
+.community-modal-info {
+  --h2-color: var(--primary-color);
+}
+.nav-file-tag {
+  line-height: 1rem;
+}
+.modal {
+  background-color: var(--background-primary);
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 20px 60px -10px rgba(0, 0, 0, 0.4);
+  overflow: auto;
+  max-width: 1100px;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
+}
+.theme-dark .modal {
+  background-color: rgba(20, 20, 25, 0.85);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.2),
+    0 30px 80px -10px rgba(0, 0, 0, 0.6);
+}
+.theme-light .modal {
+  background-color: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(20px) saturate(120%);
+  -webkit-backdrop-filter: blur(20px) saturate(120%);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: 0 10px 40px -5px rgba(0, 0, 0, 0.1);
+}
+.modal-close-button {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 10;
+  opacity: 0.6;
+  transition: all 0.2s ease;
+}
+.modal-close-button:hover {
+  opacity: 1;
+  background-color: var(--background-modifier-hover);
+  color: var(--text-error);
+  transform: rotate(90deg);
+}
+.vertical-tab-header {
+  background-color: color-mix(
+    in srgb,
+    var(--background-secondary),
+    transparent 60%
+  );
+  border-right: 1px solid var(--border-color);
+  width: 230px;
+  padding: 15px 8px;
+  flex-shrink: 0;
+}
+.vertical-tab-header-group-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin: 2px 0 4px 10px;
+}
+.vertical-tab-nav-item {
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  margin-bottom: 2px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--text-normal);
+  transition: all 0.2s ease;
+  position: relative;
+}
+.vertical-tab-nav-item-icon {
+  margin-right: 8px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  transition: color 0.2s ease;
+}
+.vertical-tab-nav-item-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2px;
+}
+.vertical-tab-nav-item:hover {
+  background-color: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+.vertical-tab-nav-item:hover .vertical-tab-nav-item-icon {
+  color: var(--text-normal);
+}
+.vertical-tab-nav-item.is-active {
+  background-color: var(--primary-color) !important;
+  color: #ffffff !important;
+  font-weight: 600;
+  box-shadow: 0 2px 8px
+    color-mix(in srgb, var(--primary-color), transparent 50%);
+}
+.vertical-tab-nav-item.is-active .vertical-tab-nav-item-icon {
+  color: #ffffff !important;
+  opacity: 1;
+}
+.workspace-leaf-content[data-type="bases"] {
+  --bases-table-row-border-width: 0px !important;
+  --bases-table-column-border-width: 0px !important;
+  --table-border-width: 0px !important;
+  --bases-table-row-height: 40px !important;
+  --bases-table-font-size: 14px !important;
+  --bases-table-header-background: var(--background-primary);
+  --bases-table-group-background: var(--background-primary);
+}
+.bases-toolbar {
+  border-bottom: 1px solid var(--border-color);
+  padding: 8px 16px;
+  gap: 12px;
+}
+.bases-toolbar .text-icon-button {
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 4px 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+  transition: all 0.2s ease;
+  box-shadow: none !important;
+}
+.bases-toolbar .text-icon-button:hover,
+.bases-toolbar .text-icon-button.is-active {
+  background-color: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+.bases-toolbar .text-button-icon svg {
+  width: 16px;
+  height: 16px;
+  opacity: 0.8;
+}
+.bases-thead {
+  background-color: var(--background-primary) !important;
+  border-bottom: 2px solid var(--background-modifier-border);
+  box-shadow: none !important;
+  z-index: 10;
+}
+.bases-table-header {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding-left: 12px;
+}
+.bases-tr {
+  box-shadow: none !important;
+  border-bottom: 1px solid transparent;
+  transition: all 0.2s cubic-bezier(0.25, 0.8, 0.25, 1);
+  cursor: pointer;
+  margin: 0 4px;
+  width: calc(100% - 8px) !important;
+  border-radius: 8px;
+}
+.bases-tr:hover {
+  background-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 88%
+  ) !important;
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.05),
+    inset 0 0 0 1px color-mix(in srgb, var(--primary-color), transparent 90%) !important;
+  border-bottom-color: transparent;
+  transform: scale(1.005);
+  z-index: 10;
+}
+.bases-tr:hover .bases-rendered-value {
+  color: var(--text-normal) !important;
+}
+.bases-tr:hover .internal-link {
+  color: var(--primary-color) !important;
+  text-decoration: none !important;
+}
+.bases-tr.is-selected {
+  background-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 80%
+  ) !important;
+  box-shadow: inset 3px 0 0 var(--primary-color);
+}
+.bases-tr:hover .bases-td:first-child {
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+.bases-tr:hover .bases-td:last-child {
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+.bases-td {
+  box-shadow: none !important;
+  padding: 0 12px !important;
+  border-right: none !important;
+}
+.bases-rendered-value {
+  padding: 0 !important;
+  display: flex;
+  align-items: center;
+}
+.bases-rendered-value .internal-link {
+  text-decoration: none !important;
+  color: var(--text-normal) !important;
+  font-weight: 400;
+  transition: color 0.2s ease;
+}
+.bases-rendered-value .internal-link:hover {
+  color: var(--primary-color) !important;
+  text-decoration: underline !important;
+  text-underline-offset: 4px;
+}
+.bases-table-header-icon {
+  display: none;
+}
+.bases-view {
+  background-color: var(--background-primary);
+}
+.theme-light .bases-tr:not(:hover) {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.03);
+}
+.theme-dark .bases-tr:not(:hover) {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+}
+body {
+  --scrollbar-bg: transparent;
+  --scrollbar-thumb-bg: rgba(var(--mono-rgb-100), 0.1);
+  --scrollbar-active-thumb-bg: rgba(var(--mono-rgb-100), 0.2);
+}
+body.theme-dark {
+  --scrollbar-thumb-bg: rgba(255, 255, 255, 0.1);
+  --scrollbar-active-thumb-bg: rgba(255, 255, 255, 0.2);
+}
+body.theme-light {
+  --scrollbar-thumb-bg: rgba(0, 0, 0, 0.1);
+  --scrollbar-active-thumb-bg: rgba(0, 0, 0, 0.2);
+}
+body:not(.restored-scrollbars) ::-webkit-scrollbar,
+body:not(.restored-scrollbars)
+  .kanban-plugin__scroll-container::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background-color: var(--scrollbar-bg);
+}
+body:not(.restored-scrollbars) ::-webkit-scrollbar-thumb,
+body:not(.restored-scrollbars)
+  .kanban-plugin__scroll-container::-webkit-scrollbar-thumb {
+  background-clip: padding-box;
+  border-radius: 20px;
+  border: 2px solid transparent;
+  min-height: 45px;
+  background-color: transparent;
+}
+body:not(.restored-scrollbars)
+  .mobile-toolbar-options-container::-webkit-scrollbar {
+  display: none;
+}
+body:not(.restored-scrollbars):not(.is-mobile) :hover::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb-bg) !important;
+}
+body:not(.restored-scrollbars) ::-webkit-scrollbar-thumb:hover,
+body:not(.restored-scrollbars) ::-webkit-scrollbar-thumb:active {
+  background-color: var(--scrollbar-active-thumb-bg) !important;
+}
+.workspace-leaf-content:is(
+    [data-type="surfing-view"],
+    [data-type="graph"],
+    [data-type="localgraph"]
+  )
+  ::-webkit-scrollbar,
+.scrollbar-hide ::-webkit-scrollbar {
+  display: none;
+}
+body.layout-cards:not(.is-mobile)
+  .workspace-tabs:not(.mod-stacked)
+  .workspace-leaf,
+body.layout-cards:not(.is-mobile)
+  .workspace-tabs:not(.mod-stacked)
+  .workspace-leaf-content,
+body.layout-cards:not(.is-mobile)
+  .workspace-tabs:not(.mod-stacked)
+  .view-header:not(.animate),
+body.layout-cards:not(.is-mobile)
+  .workspace-tabs:not(.mod-stacked)
+  .view-content:not(
+    .vignette-radial,
+    .vignette-linear,
+    .animate,
+    .ptm-fullscreen-writing-focus-element
+  ),
+body.layout-cards .mod-left-split .workspace-tab-header.has-active-menu,
+body.layout-cards .mod-right-split .workspace-tab-header.has-active-menu,
+body.layout-cards:not(.is-mobile) .workspace-tab-header-container,
+body.layout-cards .workspace > .workspace-split {
+  background-color: transparent !important;
+}
+body.layout-cards .workspace-tab-header-container,
+body.layout-cards .workspace-tabs.mod-top .workspace-tab-header-container,
+body.layout-cards .workspace-ribbon.mod-left:before {
+  border-bottom: 1px solid var(--background-card) !important;
+}
+body.layout-cards .workspace-ribbon {
+  border-right: transparent !important;
+  background-color: var(--background-card);
+}
+body.layout-cards .sidebar-toggle-button,
+body.layout-cards .workspace-tabs.mod-top {
+  background-color: var(--background-card);
+}
+body.layout-cards .workspace-ribbon.mod-left:before {
+  background: transparent !important;
+}
+body.layout-cards .workspace-leaf-resize-handle {
+  --workspace-divider-color: transparent;
+  border-color: var(--workspace-divider-color);
+}
+body.layout-cards
+  .is-hidden-frameless:not(.is-fullscreen).is-focused
+  .titlebar-button-container.mod-right {
+  background-color: transparent;
+}
+body.layout-cards:not(.is-mobile).mod-left-split
+  .workspace-sidedock-vault-profile {
+  border: 0;
+  padding: 0;
+  z-index: 99;
+}
+body.layout-cards .workspace-sidedock-vault-profile {
+  border-top: transparent !important;
+}
+body.layout-cards:not(.is-mobile)
+  .workspace-split.mod-left-split
+  .workspace-sidedock-vault-profile {
+  background-color: var(--background-card);
+}
+body.layout-cards:not(.is-mobile).theme-light .workspace-tab-container {
+  border-radius: 20px 20px 10px 10px;
+  border: 1px solid color-mix(in srgb, var(--primary-color), transparent 80%);
+  margin: 8px 10px;
+  background-color: color-mix(in srgb, var(--primary-color), #fff 96%);
+}
+body.layout-cards.theme-light .mod-vertical .workspace-tab-header-container {
+  padding-left: 20px;
+}
+body.layout-cards.theme-light
+  .mod-vertical:not(.mod-left-split):not(.mod-right-split)
+  .workspace-tabs:not(.mod-stacked)
+  .workspace-tab-header-container-inner {
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  margin-top: 3px;
+  width: 100%;
+  gap: 10px;
+  z-index: 1;
+}
+body.layout-cards.theme-light
+  .mod-vertical:not(.mod-left-split):not(.mod-right-split)
+  .workspace-tabs:not(.mod-stacked)
+  .workspace-tab-header {
+  background: color-mix(in srgb, var(--primary-color), #fff 96%);
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow:
+    0 0 8px rgba(0, 0, 0, 0.15),
+    inset 0 1px 1px rgba(255, 255, 255, 0.15);
+  height: 32px;
+  padding: 0 !important;
+  transition:
+    400ms,
+    background-color 150ms ease-in-out;
+}
+body.layout-cards.theme-light
+  .mod-vertical:not(.mod-left-split):not(.mod-right-split)
+  .workspace-tabs:not(.mod-stacked)
+  .workspace-tab-header.is-active {
+  border: 1px solid color-mix(in srgb, var(--primary-color), #fff 70%);
+  box-shadow:
+    0 0 8px color-mix(in srgb, var(--primary-color), transparent 75%),
+    inset 0 1px 1px color-mix(in srgb, var(--primary-color), transparent 75%);
+  background-color: var(--background-primary);
+  font-weight: bold;
+  flex-grow: 1.67;
+  max-width: 240px;
+}
+body.layout-cards.theme-light
+  .mod-root:not(.mod-left-split):not(.mod-right-split)
+  .workspace-tabs:not(.mod-stacked)
+  .workspace-tab-header-inner {
+  padding: 0 4px 0 8px;
+  transition:
+    400ms,
+    background-color 150ms ease-in-out,
+    max-width 400ms;
+}
+body.layout-cards .workspace-tab-header-container .workspace-tab-header::before,
+body.layout-cards .workspace-tab-header-container .workspace-tab-header::after,
+body.layout-cards .workspace .mod-root .workspace-tab-header-inner::after {
+  display: none;
+}
+body.layout-cards:not(.is-phone).theme-light .modal-container.mod-dim .modal,
+body.layout-cards:not(.is-phone).theme-light .status-bar {
+  border-radius: var(--radius-xl);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-shadow:
+    0 0 8px rgba(0, 0, 0, 0.05),
+    inset 0 1px 1px rgba(255, 255, 255, 0.5);
+  margin: 0 5px 5px 5px;
+  transform: translate(0, -5px);
+}
+body.layout-cards:not(.is-phone).theme-light .workspace-tabs {
+  background: var(--background-card);
+}
+body.layout-cards:not(.is-mobile).theme-dark .workspace-tab-container {
+  border-radius: 20px 20px 10px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin: 8px 10px;
+  background-color: var(--background-primary);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+body.layout-cards.theme-dark
+  .mod-vertical:not(.mod-left-split):not(.mod-right-split)
+  .workspace-tabs:not(.mod-stacked)
+  .workspace-tab-header {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: none;
+  height: 32px;
+  padding: 0 !important;
+  transition:
+    400ms,
+    background-color 150ms ease-in;
+}
+body.layout-cards.theme-dark
+  .mod-vertical:not(.mod-left-split):not(.mod-right-split)
+  .workspace-tabs:not(.mod-stacked)
+  .workspace-tab-header.is-active {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  background-color: var(--background-secondary);
+  font-weight: bold;
+  flex-grow: 1.67;
+  max-width: 240px;
+}
+body.layout-cards.theme-dark
+  .workspace-tab-header.is-active
+  .workspace-tab-header-inner-title {
+  color: var(--text-normal);
+}
+body.layout-cards.theme-dark
+  .mod-vertical:not(.mod-left-split):not(.mod-right-split)
+  .workspace-tabs:not(.mod-stacked)
+  .workspace-tab-header-container-inner {
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  margin-top: 3px;
+  width: 100%;
+  gap: 10px;
+}
+body.layout-cards:not(.is-phone).theme-dark .modal-container.mod-dim .modal,
+body.layout-cards:not(.is-phone).theme-dark .status-bar {
+  border-radius: var(--radius-xl);
+  background: rgba(30, 30, 30, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+  margin: 0 5px 5px 5px;
+  transform: translate(0, -5px);
+}
+.community-modal-meta {
+  display: grid;
+  grid-template-areas: "name name name name" "desc desc desc desc" "stats stats stats stats" "buttons buttons buttons buttons";
+  grid-template-columns: 2fr 2fr 2fr 1fr;
+  gap: 16px;
+  margin-bottom: 0 !important;
+}
+.community-modal-info-name {
+  grid-area: name;
+  font-size: 24px;
+  font-weight: 800;
+  color: var(--primary-color);
+  line-height: 1.2;
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.flair {
+  font-size: 11px;
+  background-color: var(--background-secondary) !important;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted) !important;
+  padding: 2px 8px;
+  border-radius: 50px;
+  text-transform: uppercase;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  top: -2px;
+  position: relative;
+}
+.flair.mod-pop {
+  color: var(--secondary-color) !important;
+  border-color: var(--secondary-color);
+  background-color: color-mix(
+    in srgb,
+    var(--secondary-color),
+    transparent 90%
+  ) !important;
+}
+.community-modal-info-desc {
+  grid-area: desc;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text-normal);
+  opacity: 0.9;
+  padding-bottom: 20px;
+  border-bottom: 1px dashed var(--border-color);
+  margin-bottom: 8px;
+}
+.community-modal-info-downloads,
+.community-modal-info-version,
+.community-modal-info-author,
+.community-modal-info-repo {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  padding: 12px;
+  background-color: var(--background-secondary);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0 !important;
+  min-width: 0;
+}
+.community-modal-info-downloads {
+  grid-area: stats;
+  grid-column: 1;
+}
+.community-modal-info-version {
+  grid-area: stats;
+  grid-column: 2;
+}
+.community-modal-info-author {
+  grid-area: stats;
+  grid-column: 3;
+}
+.community-modal-info-repo {
+  grid-area: stats;
+  grid-column: 4;
+}
+@media (max-width: 700px) {
+  .community-modal-meta {
+    grid-template-areas: "name" "desc" "stats-1" "stats-2" "stats-3" "stats-4" "buttons";
+    grid-template-columns: 1fr;
+  }
+  .community-modal-info-downloads {
+    grid-area: stats-1;
+    grid-column: auto;
+  }
+  .community-modal-info-version {
+    grid-area: stats-2;
+    grid-column: auto;
+  }
+  .community-modal-info-author {
+    grid-area: stats-3;
+    grid-column: auto;
+  }
+  .community-modal-info-repo {
+    grid-area: stats-4;
+    grid-column: auto;
+  }
+}
+.community-modal-info-downloads {
+  color: var(--text-normal);
+  font-weight: bold;
+  border: 1px solid color-mix(in srgb, var(--primary-color), transparent 80%);
+  background-color: color-mix(in srgb, var(--primary-color), transparent 96%);
+}
+.community-modal-info-downloads::before {
+  content: "DOWNLOADS";
+  font-size: 10px;
+  font-weight: bold;
+  color: var(--primary-color);
+  opacity: 0.7;
+  margin-bottom: 4px;
+  letter-spacing: 0.5px;
+}
+.community-modal-info-downloads span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 16px;
+}
+.community-modal-info-downloads svg {
+  width: 16px;
+  height: 16px;
+  color: var(--primary-color);
+}
+.community-modal-info-version::before {
+  content: "VERSION";
+}
+.community-modal-info-author::before {
+  content: "AUTHOR";
+}
+.community-modal-info-repo::before {
+  content: "REPOSITORY";
+}
+.community-modal-info-version::before,
+.community-modal-info-author::before,
+.community-modal-info-repo::before {
+  font-size: 10px;
+  font-weight: bold;
+  color: var(--text-muted);
+  opacity: 0.6;
+  margin-bottom: 2px;
+  display: block;
+}
+.community-modal-info-author a,
+.community-modal-info-repo a {
+  color: var(--text-normal);
+  text-decoration: none;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+.community-modal-info-author a:hover,
+.community-modal-info-repo a:hover {
+  color: var(--primary-color);
+  text-decoration: underline;
+}
+.community-modal-button-container {
+  grid-area: buttons;
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px dashed var(--border-color);
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.community-modal-button-container button {
+  flex: 1;
+  justify-content: center;
+}
+.codeblock-customizer-line-number,
+.codeblock-customizer-line-number-specific {
+  background: transparent;
+}
+body.rainbow-folders .nav-folder {
+  --nav-c-pink: #ff7096;
+  --nav-c-cyan: #3db8bf;
+  --nav-c-orange: #f59e0b;
+  --nav-c-green: #11aa63;
+  --nav-c-purple: #a06eb4;
+  --nav-c-red: #aa1141;
+  --nav-c-blue: #1d4e89;
+  --folder-color: var(--text-muted);
+  --nav-item-background-hover: color-mix(
+    in srgb,
+    var(--folder-color),
+    transparent 95%
+  );
+  --background-modifier-active-hover: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 95%
+  );
+}
+body.rainbow-folders .nav-files-container {
+  --folder-color: var(--primary-color);
+  --nav-item-background-hover: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 95%
+  );
+  --background-modifier-active-hover: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 90%
+  );
+}
+body.rainbow-folders
+  .nav-files-container
+  > div
+  > .nav-folder:nth-child(7n + 1) {
+  --folder-color: var(--nav-c-pink);
+}
+body.rainbow-folders
+  .nav-files-container
+  > div
+  > .nav-folder:nth-child(7n + 2) {
+  --folder-color: var(--nav-c-cyan);
+}
+body.rainbow-folders
+  .nav-files-container
+  > div
+  > .nav-folder:nth-child(7n + 3) {
+  --folder-color: var(--nav-c-orange);
+}
+body.rainbow-folders
+  .nav-files-container
+  > div
+  > .nav-folder:nth-child(7n + 4) {
+  --folder-color: var(--nav-c-green);
+}
+body.rainbow-folders
+  .nav-files-container
+  > div
+  > .nav-folder:nth-child(7n + 5) {
+  --folder-color: var(--nav-c-purple);
+}
+body.rainbow-folders
+  .nav-files-container
+  > div
+  > .nav-folder:nth-child(7n + 6) {
+  --folder-color: var(--nav-c-red);
+}
+body.rainbow-folders
+  .nav-files-container
+  > div
+  > .nav-folder:nth-child(7n + 7) {
+  --folder-color: var(--nav-c-blue);
+}
+body.rainbow-folders .nav-files-container > div > .nav-folder {
+  margin: 0 0 8px 0 !important;
+  padding: 0px 0 !important;
+  border-radius: 0 8px 8px 0;
+  border-left: 4px solid var(--folder-color) !important;
+  transition: background-color 0.2s ease;
+}
+body.rainbow-folders .nav-folder .nav-folder {
+  border-left: none !important;
+  background-color: transparent !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border-radius: 0;
+}
+body.rainbow-folders .nav-folder.is-collapsed {
+  padding-bottom: 0 !important;
+}
+body.rainbow-folders .nav-folder-title {
+  padding: 6px 8px !important;
+  margin: 1px 0 !important;
+  border-radius: 6px;
+  font-weight: 500;
+  color: var(--folder-color);
+  display: flex;
+  align-items: center;
+}
+body.rainbow-folders .nav-folder .nav-folder .nav-folder-title-content {
+  opacity: 0.9;
+}
+body.rainbow-folders .nav-folder-title:hover {
+  background-color: var(--background-modifier-hover);
+}
+body.rainbow-folders .nav-folder-collapse-indicator,
+body.rainbow-folders .nav-folder .collapse-icon {
+  display: none !important;
+}
+body.rainbow-folders .nav-folder-children {
+  margin-left: 14px !important;
+  padding-left: 10px !important;
+  border-left: 1px solid
+    color-mix(in srgb, var(--folder-color), transparent 70%);
+}
+body.rainbow-folders .nav-folder:hover > .nav-folder-children {
+  border-left-color: color-mix(in srgb, var(--folder-color), transparent 40%);
+}
+body.rainbow-folders .nav-folder-title-content::before,
+body.rainbow-folders .nav-file-title-content::before {
+  content: "";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  vertical-align: text-bottom;
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
+}
+body.rainbow-folders .nav-file-title-content::before {
+  width: 14px;
+  height: 14px;
+  opacity: 0.6;
+}
+body.rainbow-folders .nav-file-title:hover .nav-file-title-content::before {
+  opacity: 0.9;
+}
+body.rainbow-folders .nav-folder-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z'/%3E%3C/svg%3E");
+  opacity: 0.8;
+}
+body.rainbow-folders
+  .nav-folder:not(.is-collapsed)
+  > .nav-folder-title
+  .nav-folder-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2'/%3E%3C/svg%3E");
+  opacity: 1;
+}
+body.rainbow-folders .nav-file-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");
+}
+body.rainbow-folders
+  .nav-file-title[data-path$=".png" i]
+  .nav-file-title-content::before,
+body.rainbow-folders
+  .nav-file-title[data-path$=".jpg" i]
+  .nav-file-title-content::before,
+body.rainbow-folders
+  .nav-file-title[data-path$=".jpeg" i]
+  .nav-file-title-content::before,
+body.rainbow-folders
+  .nav-file-title[data-path$=".gif" i]
+  .nav-file-title-content::before,
+body.rainbow-folders
+  .nav-file-title[data-path$=".svg" i]
+  .nav-file-title-content::before,
+body.rainbow-folders
+  .nav-file-title[data-path$=".webp" i]
+  .nav-file-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='3' rx='2' ry='2'/%3E%3Ccircle cx='9' cy='9' r='2'/%3E%3Cpath d='m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='3' rx='2' ry='2'/%3E%3Ccircle cx='9' cy='9' r='2'/%3E%3Cpath d='m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21'/%3E%3C/svg%3E");
+}
+body.rainbow-folders
+  .nav-file-title[data-path$=".canvas" i]
+  .nav-file-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='7' height='9' x='3' y='3' rx='1'/%3E%3Crect width='7' height='5' x='14' y='3' rx='1'/%3E%3Crect width='7' height='9' x='14' y='12' rx='1'/%3E%3Crect width='7' height='5' x='3' y='16' rx='1'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='7' height='9' x='3' y='3' rx='1'/%3E%3Crect width='7' height='5' x='14' y='3' rx='1'/%3E%3Crect width='7' height='9' x='14' y='12' rx='1'/%3E%3Crect width='7' height='5' x='3' y='16' rx='1'/%3E%3C/svg%3E");
+}
+body.rainbow-folders
+  .nav-file-title[data-path$=".base" i]
+  .nav-file-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E");
+}
+body.theme-light.rainbow-folders .nav-files-container > div > .nav-folder {
+  background-color: color-mix(in srgb, var(--folder-color), transparent 96%);
+  border-top: 1px solid color-mix(in srgb, var(--folder-color), transparent 92%);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--folder-color), transparent 92%);
+  border-right: 1px solid
+    color-mix(in srgb, var(--folder-color), transparent 92%);
+}
+body.theme-light.rainbow-folders
+  .nav-files-container
+  > div
+  > .nav-folder:hover {
+  background-color: color-mix(in srgb, var(--folder-color), transparent 92%);
+}
+body.theme-dark.rainbow-folders .nav-files-container > div > .nav-folder {
+  background-color: color-mix(in srgb, var(--folder-color), transparent 96%);
+  border-top: 1px solid color-mix(in srgb, var(--folder-color), transparent 95%);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--folder-color), transparent 95%);
+  border-right: 1px solid
+    color-mix(in srgb, var(--folder-color), transparent 95%);
+}
+body.theme-dark.rainbow-folders .nav-files-container > div > .nav-folder:hover {
+  background-color: color-mix(in srgb, var(--folder-color), transparent 92%);
+}
+body.rainbow-folders .nav-file-title {
+  padding: 4px 8px !important;
+  border-radius: 6px;
+  color: var(--text-muted);
+}
+body.rainbow-folders .nav-file-title:hover {
+  background-color: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+body.rainbow-folders .nav-file-title.is-active {
+  background-color: var(--background-modifier-active-hover);
+  color: var(--primary-color);
+  font-weight: 600;
+}
+body.rainbow-folders .nav-file-title.is-active .nav-file-title-content::before {
+  background-color: var(--primary-color);
+  opacity: 1;
+}
+@media (hover: hover) {
+  body.rainbow-folders:not(.is-grabbing) .tree-item-self.is-clickable:hover {
+    color: var(--folder-color);
+    font-weight: bolder;
+  }
+}
+.nav-files-container > div > .nav-folder {
+  margin: 0 0 8px 0 !important;
+  padding: 0 !important;
+  border-left: 3px solid var(--folder-color) !important;
+  border-radius: 0 6px 6px 0;
+  transition: background-color 0.2s ease;
+}
+.nav-folder .nav-folder {
+  border-left: none !important;
+  background-color: transparent !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border-radius: 0;
+}
+.nav-folder.is-collapsed {
+  padding-bottom: 0 !important;
+}
+.nav-folder-title {
+  padding: 4px 6px !important;
+  margin: 1px 0 !important;
+  border-radius: 4px;
+  font-weight: 500;
+  color: var(--folder-color);
+  display: flex;
+  align-items: center;
+}
+.nav-files-container > div > .nav-folder > .nav-folder-title {
+  padding-left: 8px !important;
+}
+.nav-folder .nav-folder .nav-folder-title-content {
+  opacity: 0.9;
+}
+.nav-folder-title:hover {
+  background-color: var(--background-modifier-hover);
+}
+.nav-folder-collapse-indicator,
+.nav-folder .collapse-icon {
+  display: none !important;
+}
+.nav-folder-title-content::before,
+.nav-file-title-content::before {
+  content: "";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  vertical-align: text-bottom;
+  background-color: currentColor;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease;
+}
+.nav-file-title-content::before {
+  width: 14px;
+  height: 14px;
+  opacity: 0.6;
+}
+.nav-file-title:hover .nav-file-title-content::before {
+  opacity: 0.9;
+}
+.nav-folder-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z'/%3E%3C/svg%3E");
+  opacity: 0.8;
+}
+.nav-folder:not(.is-collapsed)
+  > .nav-folder-title
+  .nav-folder-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2'/%3E%3C/svg%3E");
+  opacity: 1;
+}
+.nav-file-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");
+}
+.nav-file-title[data-path$=".png" i] .nav-file-title-content::before,
+.nav-file-title[data-path$=".jpg" i] .nav-file-title-content::before,
+.nav-file-title[data-path$=".jpeg" i] .nav-file-title-content::before,
+.nav-file-title[data-path$=".gif" i] .nav-file-title-content::before,
+.nav-file-title[data-path$=".svg" i] .nav-file-title-content::before,
+.nav-file-title[data-path$=".webp" i] .nav-file-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='3' rx='2' ry='2'/%3E%3Ccircle cx='9' cy='9' r='2'/%3E%3Cpath d='m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='18' height='18' x='3' y='3' rx='2' ry='2'/%3E%3Ccircle cx='9' cy='9' r='2'/%3E%3Cpath d='m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21'/%3E%3C/svg%3E");
+}
+.nav-file-title[data-path$=".canvas" i] .nav-file-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='7' height='9' x='3' y='3' rx='1'/%3E%3Crect width='7' height='5' x='14' y='3' rx='1'/%3E%3Crect width='7' height='9' x='14' y='12' rx='1'/%3E%3Crect width='7' height='5' x='3' y='16' rx='1'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='7' height='9' x='3' y='3' rx='1'/%3E%3Crect width='7' height='5' x='14' y='3' rx='1'/%3E%3Crect width='7' height='9' x='14' y='12' rx='1'/%3E%3Crect width='7' height='5' x='3' y='16' rx='1'/%3E%3C/svg%3E");
+}
+.nav-file-title[data-path$=".base" i] .nav-file-title-content::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E");
+}
+.nav-file-title {
+  padding: 4px 8px !important;
+  border-radius: 6px;
+  color: var(--text-muted);
+}
+.nav-file-title:hover {
+  background-color: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+.nav-file-title.is-active {
+  background-color: var(--background-modifier-active-hover);
+  color: var(--primary-color);
+  font-weight: 600;
+}
+.nav-file-title.is-active .nav-file-title-content::before {
+  background-color: var(--primary-color);
+  opacity: 1;
+}
+@media (hover: hover) {
+  body:not(.is-grabbing) .tree-item-self.is-clickable:hover {
+    color: var(--folder-color);
+    font-weight: bolder;
+  }
+}
+.codeblock-customizer-active-line-highlight .cm-active,
+.codeblock-customizer-active-line-highlight-editor .cm-active {
+  background-color: color-mix(
+    in srgb,
+    var(--primary-color),
+    transparent 95%
+  ) !important;
+}


### PR DESCRIPTION
## 背景

作为 Phycat 主题的深度用户，非常喜欢这个主题在深色模式下的语法标记设计——粗体、斜体、高亮各有清晰区分，hover 动画精致流畅。在日常使用中发现了一些可以改进的地方，于是基于当前版本做了一轮增强。所有新功能通过 Style Settings toggle 控制，**默认关闭，不影响现有体验**。

---

## 改动内容

### 1. 浅色模式语法标记配色重新设计

**问题：** 深色模式下粗体（primary-color）、斜体（secondary-color）、高亮各有不同颜色，区分度很好。但多数浅色主题中，正文颜色已带主题色调（如 Forest 的灰绿正文、Mauve 的紫色正文），粗体 \`--text-bold\` 使用的 \`--light-deep\` 与正文同色系，斜体 \`--secondary-color\` 也与 \`--primary-color\` 色相过近，导致**粗体、斜体、高亮在浅色模式下几乎无法区分**。

**方案：** 照搬深色模式的"三层分离"逻辑，为每个浅色主题重新选色：
- **粗体**：对比色主强调（如 Forest 用深紫 \`#8e24aa\` 对抗灰绿正文）
- **斜体**：引入独立变量 \`--text-italic\`，与 \`--secondary-color\` 解耦，选用与粗体色相差距大的次级强调色
- **高亮**：引入 \`--text-highlight\` 变量，默认跟随各主题次级强调色

各主题配色：

| 主题 | 正文色调 | 粗体（新） | 斜体（新） |
|------|---------|----------|----------|
| 🌸 Sakura | 中性黑 | \`#e91e63\` 深粉（不变） | \`#0277bd\` 海洋蓝 |
| ☁️ Sky | 近黑 | \`#1a5276\` 深蓝（不变） | \`#c56200\` 焦橙 |
| 🌲 Forest | 灰绿 | \`#8e24aa\` 深紫 | \`#bf6c00\` 琥珀 |
| 🌊 Mint | 蓝灰 | \`#c2185b\` 深玫红 | \`#e65100\` 焦橙 |
| 🟣 Mauve | 紫 | \`#00838f\` 深青 | \`#c56200\` 焦橙 |
| 🌅 Golden | 琥珀 | \`#4527a0\` 深靛蓝 | \`#00796b\` 深青 |
| 🍒 Cheery | 暗红 | \`#00695c\` 深青 | \`#4527a0\` 深靛蓝 |
| ⚓ Prussian | 蓝 | \`#c62828\` 深红 | \`#bf6c00\` 琥珀 |

### 2. Style Settings 颜色面板

新增 **✏️ Phycat syntax mark setting** 面板，暴露 6 个颜色选择器（粗体/斜体/高亮 × 亮色/暗色）。使用 \`var(--xxx, fallback)\` 模式，用户不改则使用各主题默认色，改了则全局覆盖。

### 3. 编辑模式标题 Hover 特效（Toggle）

**问题：** 阅读模式下各级标题有精心设计的 hover 动画（H1 下划线展开、H2 双子条动画、H3 竖条增长、H4 圆点放大、H5 空心填充、H6 破折号拉伸），但编辑模式完全没有。

**方案：** 在 📑 标题设置面板新增 \`class-toggle\`，开启后编辑模式获得与阅读模式**完全一致**的 hover 体验：

- H1~H6 所有级别、亮暗两套、所有风格变体（居中/左对齐、胶囊/双柱）
- H3~H6 编辑模式 \`::before\` 定位从 \`margin-top\` 改为 \`top:50%+translateY(-50%)\` 居中方案
- H4~H6 编辑模式 \`::before\` 补上 \`transition\` 过渡动画
- H4~H6 补齐 \`::before:hover\` 特效（圆点缩放+光环、空心填充、破折号拉伸）

**额外改进：**
- H1 左对齐 + H2 twin 模式 hover 加 \`translateX(5px)\` 右移，与 H3~H6 统一
- H3 阅读模式 \`::before:hover\` 补上 \`box-shadow\` 光环效果（H4/H5 都有，H3 疑似遗漏）
- H6 编辑模式 \`::before\` 去掉 \`font-family: monospace\`，与阅读模式字体一致
- H2 twin 的 \`transition: color\` 改为 \`transition: all\`，使 translateX 位移也有过渡

### 4. 编辑模式 Wikilink 样式（Toggle）

**问题：** 阅读模式的 \`a.internal-link\` 有单括号装饰 + hover 高亮展开动画，但编辑模式的 \`cm-hmd-internal-link\` 没有样式。

**方案：** 新增 **🔗 Phycat link setting** 面板，提供 \`class-toggle\`：
- 单括号 \`[\` \`]\` 装饰（\`::before\`/\`::after\`）
- Hover 时背景高亮 + 括号展开动画
- 光标进入链接时通过 CSS 相邻兄弟选择器检测 \`.cm-formatting-link\`，自动隐藏装饰括号，避免与 Obsidian 原生 \`[[\` \`]]\` 标记重复

---

## 技术要点

- 所有新功能通过 Style Settings \`class-toggle\` 控制，**默认关闭**
- \`--text-italic\` 独立于 \`--secondary-color\`，不影响链接、装饰等其他引用处
- \`--text-highlight\` 独立于 \`--primary-color\`，不影响其他引用处
- theme.css 已通过 Prettier 格式化（原文件第 484 行为 13 万字符的 minified CSS，已展开为可读格式）

## 测试

已在 Obsidian 中逐项测试：
- [x] 8 个浅色主题语法标记区分度
- [x] 3 个深色主题不受影响
- [x] Style Settings 颜色选择器正常工作
- [x] 标题 hover toggle 开关，H1~H6 全级别全风格验证
- [x] Wikilink toggle 开关，光标进入时括号正确隐藏
- [x] 亮色/暗色模式切换无异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)