### PR TITLE
fix: file icon fallback with plugin icons

### DIFF
--- a/theme-origin.css
+++ b/theme-origin.css
@@ -5030,6 +5030,7 @@ body.rainbow-folders .nav-file-title.is-active .nav-file-title-content::before {
   display: none !important
 }
 
+@layer phycat-file-icons {
 .nav-folder-title-content::before,
 .nav-file-title-content::before {
   content: "";
@@ -5091,6 +5092,15 @@ body.rainbow-folders .nav-file-title.is-active .nav-file-title-content::before {
 .nav-file-title[data-path$=".base" i] .nav-file-title-content::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cellipse cx='12' cy='5' rx='9' ry='3'/%3E%3Cpath d='M3 5V19A9 3 0 0 0 21 19V5'/%3E%3Cpath d='M3 12A9 3 0 0 0 21 12'/%3E%3C/svg%3E")
+}
+}
+
+/* If another plugin injects a file/folder icon element, hide the theme fallback pseudo-icon. */
+.nav-file-title-content:has(svg, .svg-icon, .iconize-icon, .nav-file-icon)::before,
+.nav-file-title:has(.nav-file-icon, .iconize-icon) .nav-file-title-content::before,
+.nav-folder-title-content:has(svg, .svg-icon, .iconize-icon, .nav-folder-icon)::before,
+.nav-folder-title:has(.nav-folder-icon, .iconize-icon) .nav-folder-title-content::before {
+  display: none;
 }
 
 .nav-file-title {

--- a/theme.css
+++ b/theme.css
@@ -89,6 +89,12 @@ settings:
                 value: theme-dark-radiation
 */
 
+/* If another plugin injects a file/folder icon element, hide the theme fallback pseudo-icon. */
+.nav-file-title-content:has(svg, .svg-icon, .iconize-icon, .nav-file-icon)::before,
+.nav-file-title:has(.nav-file-icon, .iconize-icon) .nav-file-title-content::before,
+.nav-folder-title-content:has(svg, .svg-icon, .iconize-icon, .nav-folder-icon)::before,
+.nav-folder-title:has(.nav-folder-icon, .iconize-icon) .nav-folder-title-content::before{display:none !important;}
+
 
 /* @settings
 name: 🗂️ Phycat card Layout


### PR DESCRIPTION
修复：与 Iconize 等插件共存时的文件/文件夹图标回退策略

  ## 问题
目前主题会绘制自定义图标，安装 Iconize 等修改文件图标的插件后，会出现图标重复显示。

  ##  改动内容

  - 新增自动兼容：当文件树已被插件注入图标元素（如 svg / .svg-icon / .iconize-icon / .nav-file-icon 等）时，隐藏主题的 ::before 伪元素图标，避免双图标。
  - 将主题的文件/文件夹 ::before 图标规则放入低优先级 `@layer phycat-file-icons`，让外部插件的图标样式更容易覆盖。

  ## 效果
优先显示插件图标，无插件图标则继续使用主题默认的图标。


